### PR TITLE
Add ARM64/aarch64 multi-platform build with Google Coral USB Edge TPU support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,6 +17,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /app
 # Minimal runtime libs for opencv-python on slim images + feranick's maintained
 # Coral Edge TPU runtime for Debian trixie (arm64)
 # See: https://github.com/feranick/libedgetpu/releases
+ARG TARGETARCH
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         libgl1 \
@@ -17,9 +18,11 @@ RUN apt-get update \
         curl \
         wget \
         libusb-1.0-0 \
-    && wget -q https://github.com/feranick/libedgetpu/releases/download/16.0TF2.19.1-1/libedgetpu1-std_16.0tf2.19.1-1.trixie_arm64.deb \
-    && dpkg -i libedgetpu1-std_16.0tf2.19.1-1.trixie_arm64.deb \
-    && rm libedgetpu1-std_16.0tf2.19.1-1.trixie_arm64.deb \
+    && if [ "${TARGETARCH}" = "arm64" ]; then \
+        wget -q https://github.com/feranick/libedgetpu/releases/download/16.0TF2.19.1-1/libedgetpu1-std_16.0tf2.19.1-1.trixie_arm64.deb; \
+        dpkg -i libedgetpu1-std_16.0tf2.19.1-1.trixie_arm64.deb; \
+        rm libedgetpu1-std_16.0tf2.19.1-1.trixie_arm64.deb; \
+    fi \
     && rm -rf /var/lib/apt/lists/*
 
 # Core Python deps (ONNX is now the default backend)

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,19 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-# Minimal runtime libs for opencv-python on slim images
+# Minimal runtime libs for opencv-python on slim images + feranick's maintained
+# Coral Edge TPU runtime for Debian trixie (arm64)
+# See: https://github.com/feranick/libedgetpu/releases
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         libgl1 \
         libglib2.0-0 \
+        curl \
+        wget \
+        libusb-1.0-0 \
+    && wget -q https://github.com/feranick/libedgetpu/releases/download/16.0TF2.19.1-1/libedgetpu1-std_16.0tf2.19.1-1.trixie_arm64.deb \
+    && dpkg -i libedgetpu1-std_16.0tf2.19.1-1.trixie_arm64.deb \
+    && rm libedgetpu1-std_16.0tf2.19.1-1.trixie_arm64.deb \
     && rm -rf /var/lib/apt/lists/*
 
 # Core Python deps (ONNX is now the default backend)
@@ -25,11 +33,15 @@ RUN python -m pip install --upgrade pip \
         pydantic-settings \
         pillow \
         exceptiongroup \
-        numpy \
+        "numpy<2.0" \
         onnxruntime \
         opencv-python \
         scipy \
         shapely
+
+# Install tflite-runtime for Coral Edge TPU support
+# Compatible with feranick's libedgetpu 16.0TF2.19.1-1
+RUN pip install tflite-runtime==2.14.0
 
 # Optional: install tensorflow for tflite backend support
 # Usage: docker build --build-arg INSTALL_TENSORFLOW=1 ...

--- a/api/v1/endpoints/detection.py
+++ b/api/v1/endpoints/detection.py
@@ -56,6 +56,11 @@ async def detect_objects(
     - **min_height**: Minimum height filter for detections
     """
     logger.info(f"Detection request: backend={backend}, confidence={confidence_threshold}, filename={file.filename}")
+    # Remap tflite to edgetpu if edgetpu is set as default backend
+    # This allows LightNVR (which has no edgetpu option) to use the Coral TPU
+    if backend == "tflite" and settings.DEFAULT_BACKEND == "edgetpu":
+        backend = "edgetpu"
+        logger.info("Remapping tflite backend request to edgetpu")
 
     # Validate backend
     if backend not in settings.AVAILABLE_BACKENDS:


### PR DESCRIPTION
## Summary

This PR adds two things:

1. **ARM64 multi-platform Docker build** — enables light-object-detect to run on Raspberry Pi 4/5 and other aarch64 devices
2. **Google Coral USB Accelerator support** — installs feranick's maintained libedgetpu runtime, enabling hardware-accelerated inference on the Coral USB TPU
3. **Backend remapping for LightNVR compatibility** — allows LightNVR (which has no edgetpu backend option in its UI) to transparently use the Coral TPU when DEFAULT_BACKEND=edgetpu is set

## Motivation

LightNVR explicitly targets Raspberry Pi as a deployment platform via its Home Assistant add-on, but light-object-detect has no ARM64 image, making the integration unusable on the most common LightNVR hardware. This PR closes that gap.

The Google Coral USB Accelerator (unlike M.2/PCIe variants) does not require the gasket kernel driver — only libedgetpu — making it straightforward to include in a container image.

## Changes

- **Dockerfile**: Replaced Google's archived libedgetpu with feranick's actively maintained fork (16.0TF2.19.1-1), which is compatible with tflite-runtime 2.14.0 on Python 3.11 ARM64. Added libusb-1.0-0 dependency.
- **`.github/workflows/docker-publish.yml`**: Added `linux/arm64` to build platforms
- **`api/v1/endpoints/detection.py`**: Added tflite → edgetpu remapping when DEFAULT_BACKEND=edgetpu, enabling transparent Coral TPU usage from LightNVR

## Testing

Tested on:
- **Hardware**: Raspberry Pi 4 (2GB, aarch64)
- **OS**: Home Assistant OS 18.2
- **Coral**: Google Coral USB Accelerator (WA1, USB 3.0, ID `1a6e:089a`)
- **Detection speed**: ~27ms per frame (vs ~130ms CPU-only ONNX)
- **Streams**: 6 simultaneous camera streams via LightNVR

## Usage

```bash
# Run with Coral TPU
docker run -d \
  --name light-object-detect \
  --network host \
  --device /dev/bus/usb \
  -e DEFAULT_BACKEND=edgetpu \
  ghcr.io/opensensor/light-object-detect:latest
```

## Notes

- Google's official pycoral library is archived and only supports Python 3.6-3.9. This PR uses feranick's maintained libedgetpu fork instead, which works with Python 3.11 and current tflite-runtime versions.
- The tflite → edgetpu remapping is only active when DEFAULT_BACKEND=edgetpu is explicitly set, so existing behavior is unchanged for all other configurations.
- The Coral USB Accelerator initializes in ~3 seconds on first start.

## Acknowledgements
This PR was developed with the assistance of Claude (Anthropic's AI assistant), 
which helped with debugging, Dockerfile configuration, and documentation. 
The testing and validation were performed on real hardware by the contributor.