### PR TITLE
Fixed-budget tiled detection to recover small-object resolution

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -23,6 +23,9 @@ accelerate = ">=1.10.0"
 
 [dev-packages]
 ultralytics = "*"
+# Optional: the suites in tests/ are stdlib-only and self-run under plain
+# `python3 tests/test_*.py`, so pytest is a convenience, not a requirement.
+pytest = "*"
 
 [requires]
 python_version = "3.13"

--- a/api/v1/endpoints/detection.py
+++ b/api/v1/endpoints/detection.py
@@ -7,17 +7,118 @@ from PIL import Image
 import time
 import logging
 
-from models.detection import DetectionResponse, DetectionResult, ImageResponse, DescribeResponse, QueryResponse
+from models.detection import (
+    DetectionResponse, DetectionResult, BoundingBox, ImageResponse,
+    DescribeResponse, QueryResponse,
+)
 from models.zone import ZoneConfiguration
 from backends.factory import get_backend, BACKEND_REGISTRY
 from utils.image import validate_image, preprocess_image, image_to_bytes
 from utils.zones import filter_detections_by_zones, apply_class_filter, apply_size_filter
+from utils.tiling import (
+    MAX_TILES, TileDetection, is_truncated, map_tile_box_to_frame,
+    merge_tile_detections, plan_tiles, select_tiles, sweep_cycles,
+    tile_grid_overflowed,
+)
 from config import settings
 
 # Configure logger
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+async def _detect_tiled(
+    detector,
+    image,
+    threshold: float,
+    budget: int,
+    min_object_px: int,
+    overlap: float,
+    tile_period: float,
+    deadline_s: float,
+    start_time: float,
+) -> tuple:
+    """Run up to ``budget`` inferences over a rotating tile grid and merge the results.
+
+    Returns ``(detections, tiles_run, plan_size)``. Detections come back in
+    frame-normalized coordinates, so the existing zone/class/size filters apply
+    downstream unchanged.
+    """
+    frame_w, frame_h = image.size
+    model_w = getattr(detector, "input_width", 0) or 640
+    model_h = getattr(detector, "input_height", 0) or 640
+
+    plan = plan_tiles(frame_w, frame_h, model_w, model_h, min_object_px, overlap)
+    if tile_grid_overflowed(frame_w, frame_h, model_w, model_h, min_object_px, overlap):
+        logger.warning(
+            "Tiling: grid for %dx%d at min_object_px=%d exceeds the %d-tile cap and was "
+            "truncated — raise min_object_px or the sweep will not cover the frame",
+            frame_w, frame_h, min_object_px, MAX_TILES,
+        )
+
+    # Cursor is keyed to when the request began, so a request that happens to span a
+    # second boundary still picks one consistent tile set.
+    selected = select_tiles(plan, budget, tile_period, start_time)
+    logger.info(
+        "Tiling: %dx%d frame, %d-tile grid, running %d this cycle (full sweep %d cycles)",
+        frame_w, frame_h, len(plan), len(selected), sweep_cycles(len(plan), budget),
+    )
+
+    collected = []
+    tiles_run = 0
+    for tile in selected:
+        # Always run tile 0 so a slow host degrades to current behaviour rather than
+        # returning nothing. Only then does the deadline gate subsequent tiles.
+        if tiles_run and (time.time() - start_time) >= deadline_s:
+            logger.warning(
+                "Tiling: deadline of %.1fs reached, stopping after %d/%d tiles — "
+                "results are partial for this cycle",
+                deadline_s, tiles_run, len(selected),
+            )
+            break
+
+        crop = image if tile.full_frame else image.crop(tile.box)
+        tile_detections = await asyncio.to_thread(
+            detector.detect, crop, confidence_threshold=threshold
+        )
+        tiles_run += 1
+
+        for det in tile_detections:
+            b = det.bounding_box
+            tile_box = (b.x_min, b.y_min, b.x_max, b.y_max)
+            collected.append(
+                TileDetection(
+                    label=det.label,
+                    confidence=det.confidence,
+                    box=map_tile_box_to_frame(tile_box, tile, frame_w, frame_h),
+                    tile_index=tile.index,
+                    truncated=(
+                        not tile.full_frame
+                        and is_truncated(tile_box, tile, frame_w, frame_h)
+                    ),
+                )
+            )
+
+    merged = merge_tile_detections(
+        collected, iou_threshold=settings.TILE_IOU_THRESHOLD
+    )
+    logger.info(
+        "Tiling: %d raw detections across %d tiles merged to %d",
+        len(collected), tiles_run, len(merged),
+    )
+
+    detections = [
+        DetectionResult(
+            label=m.label,
+            confidence=m.confidence,
+            bounding_box=BoundingBox(
+                x_min=m.box[0], y_min=m.box[1], x_max=m.box[2], y_max=m.box[3]
+            ),
+        )
+        for m in merged
+    ]
+    return detections, tiles_run, len(plan)
 
 
 @router.post("/detect", response_model=DetectionResponse)
@@ -42,6 +143,34 @@ async def detect_objects(
     min_height: Optional[float] = Query(
         None, description="Minimum normalized height for detections (0-1)", ge=0.0, le=1.0
     ),
+    tiles: int = Query(
+        settings.TILE_BUDGET,
+        description="Inferences per request (T). 1 disables tiling and uses the whole frame.",
+        ge=1, le=MAX_TILES,
+    ),
+    min_object_px: int = Query(
+        settings.TILE_MIN_OBJECT_PX,
+        description="Smallest object to resolve, in source pixels. Drives the tile size.",
+        ge=1,
+    ),
+    tile_overlap: float = Query(
+        settings.TILE_OVERLAP,
+        description="Overlap between adjacent tiles as a fraction of tile size",
+        ge=0.0, lt=1.0,
+    ),
+    tile_period: float = Query(
+        settings.TILE_PERIOD_SECONDS,
+        description="Rotation cursor period in seconds; match the stream's detection_interval",
+        gt=0.0,
+    ),
+    tile_deadline_s: float = Query(
+        settings.TILE_DEADLINE_SECONDS,
+        description="Stop issuing tiles once this many seconds have elapsed",
+        gt=0.0,
+    ),
+    stream: Optional[str] = Query(
+        None, description="Stream name, logged for correlation (used by change-priority later)"
+    ),
 ):
     """
     Detect objects in an uploaded image using the specified backend.
@@ -54,8 +183,21 @@ async def detect_objects(
     - **filter_classes**: Comma-separated list of classes to detect
     - **min_width**: Minimum width filter for detections
     - **min_height**: Minimum height filter for detections
+    - **tiles**: Fixed inference budget T per request. With T>1 the frame is split into
+      overlapping crops sized so a `min_object_px` object survives the scale down to
+      model input; tile 0 is always the whole frame and the remaining T-1 rotate over
+      the grid on a clock-derived cursor. Cost is exactly T inferences regardless of
+      scene content.
+    - **min_object_px**: Smallest object to resolve, in source pixels
+    - **tile_overlap**: Overlap between adjacent tiles (0-1)
+    - **tile_period**: Rotation period in seconds; set to the stream's detection_interval
+    - **tile_deadline_s**: Elapsed-time budget after which remaining tiles are skipped
+    - **stream**: Stream name, logged for correlation
     """
-    logger.info(f"Detection request: backend={backend}, confidence={confidence_threshold}, filename={file.filename}")
+    logger.info(
+        f"Detection request: backend={backend}, confidence={confidence_threshold}, "
+        f"filename={file.filename}, stream={stream}, tiles={tiles}"
+    )
     # Remap tflite to edgetpu if edgetpu is set as default backend
     # This allows LightNVR (which has no edgetpu option) to use the Coral TPU
     if backend == "tflite" and settings.DEFAULT_BACKEND == "edgetpu":
@@ -85,7 +227,11 @@ async def detect_objects(
         image = Image.open(io.BytesIO(contents))
         logger.debug(f"Image opened: size={image.size}, mode={image.mode}")
         validate_image(image, file.filename)
-        processed_image = preprocess_image(image)
+        # Full resolution survives to the backend: it letterboxes to model input
+        # itself, so an intermediate downscale here would only cost small objects.
+        processed_image = preprocess_image(
+            image, max_size=settings.MAX_DETECTION_IMAGE_SIZE
+        )
         logger.debug(f"Image preprocessed: size={processed_image.size}")
     except Exception as e:
         logger.error(f"Image validation/processing failed: {str(e)}")
@@ -105,11 +251,29 @@ async def detect_objects(
     # so health probes can still respond during long-running inference).
     start_time = time.time()
     try:
-        detections = await asyncio.to_thread(
-            detector.detect, processed_image, confidence_threshold=threshold
-        )
+        if tiles > 1:
+            detections, tiles_run, plan_size = await _detect_tiled(
+                detector=detector,
+                image=processed_image,
+                threshold=threshold,
+                budget=tiles,
+                min_object_px=min_object_px,
+                overlap=tile_overlap,
+                tile_period=tile_period,
+                deadline_s=tile_deadline_s,
+                start_time=start_time,
+            )
+        else:
+            # Untiled path, unchanged: one inference over the whole frame.
+            tiles_run, plan_size = 1, 1
+            detections = await asyncio.to_thread(
+                detector.detect, processed_image, confidence_threshold=threshold
+            )
         detection_time = time.time() - start_time
-        logger.info(f"Detection completed: {len(detections)} objects found in {detection_time*1000:.1f}ms")
+        logger.info(
+            f"Detection completed: {len(detections)} objects found in "
+            f"{detection_time*1000:.1f}ms ({tiles_run}/{plan_size} tiles)"
+        )
 
         # Log detected objects
         if detections:

--- a/config.py
+++ b/config.py
@@ -53,7 +53,20 @@ class Settings(BaseSettings):
 
     # Image settings
     MAX_IMAGE_SIZE: int = 1024  # Maximum dimension (width or height) in pixels
+    # Detection keeps full resolution: the backend letterboxes to model input anyway,
+    # so an intermediate downscale only costs small objects. This is a sanity ceiling
+    # against absurd uploads, not a working limit — it should sit far above any real frame.
+    MAX_DETECTION_IMAGE_SIZE: int = 8192
     SUPPORTED_FORMATS: List[str] = ["jpg", "jpeg", "png"]
+
+    # Tiled detection defaults (see utils/tiling.py). All are overridable per-request
+    # via query params on /v1/detect, which is how lightNVR configures them per stream.
+    TILE_BUDGET: int = 1              # T: inferences per request; 1 disables tiling
+    TILE_MIN_OBJECT_PX: int = 60      # smallest object to resolve, in source pixels
+    TILE_OVERLAP: float = 0.25        # fraction of tile size overlapped with neighbours
+    TILE_PERIOD_SECONDS: float = 1.0  # rotation cursor period; match detection_interval
+    TILE_DEADLINE_SECONDS: float = 7.0  # stop issuing tiles at this elapsed time
+    TILE_IOU_THRESHOLD: float = 0.45  # cross-tile NMS threshold
     
     class Config:
         env_file = ".env"

--- a/tests/test_tiling.py
+++ b/tests/test_tiling.py
@@ -106,12 +106,36 @@ class TestPlanTiles(unittest.TestCase):
     def test_grid_is_capped_and_overflow_is_reported(self):
         # A very small min_object_px explodes the grid; the cap holds and the
         # companion predicate tells the caller it was truncated.
-        plan = plan_tiles(4000, 3000, 640, 640, 2000)
-        self.assertLessEqual(len(plan), MAX_TILES)
-        if len(plan) == MAX_TILES:
-            self.assertTrue(
-                tile_grid_overflowed(4000, 3000, 640, 640, 2000)
-            )
+        #
+        # min_object_px must be *small* to overflow: it shrinks the crop, which
+        # multiplies the tile count. An earlier version of this test passed 2000,
+        # which is large enough to collapse the grid to the single full-frame tile,
+        # so every assertion below passed without the overflow path ever running.
+        plan = plan_tiles(4000, 3000, 640, 640, 8)
+        self.assertEqual(len(plan), MAX_TILES, "expected the cap to bind here")
+        self.assertTrue(tile_grid_overflowed(4000, 3000, 640, 640, 8))
+
+    def test_crop_scale_never_puts_the_target_below_the_model_floor(self):
+        """The invariant the whole module is built on, asserted rather than assumed.
+
+        A min_object_px object inside a crop, scaled down to model input, must land
+        at or above MIN_MODEL_PX. Rounding the crop size up instead of down breaks
+        this by a fraction of a pixel, which is exactly the kind of drift no other
+        test here would notice.
+        """
+        for img_w, img_h in [(1920, 1080), (2592, 1944), (3840, 2160)]:
+            for min_object_px in range(10, 201, 7):
+                plan = plan_tiles(img_w, img_h, 640, 640, min_object_px)
+                for tile in plan:
+                    if tile.full_frame:
+                        continue  # tile 0 is the un-magnified baseline by design
+                    scale = 640.0 / max(tile.width, tile.bottom - tile.top)
+                    self.assertGreaterEqual(
+                        min_object_px * scale, MIN_MODEL_PX,
+                        f"{img_w}x{img_h} min_object_px={min_object_px}: a "
+                        f"{min_object_px}px object reaches the model at "
+                        f"{min_object_px * scale:.4f}px, under the {MIN_MODEL_PX}px floor",
+                    )
 
     def test_overflow_predicate_false_for_normal_grids(self):
         self.assertFalse(tile_grid_overflowed(1920, 1080, 640, 640, 60))

--- a/tests/test_tiling.py
+++ b/tests/test_tiling.py
@@ -1,0 +1,394 @@
+"""Tests for utils/tiling.py — tile geometry, rotation and cross-tile merge.
+
+Stdlib only, matching test_onnx_providers.py: utils/tiling.py deliberately has no
+third-party imports, so this runs on a machine with no numpy, pydantic or model file.
+
+    python3 tests/test_tiling.py      # or: pytest tests/test_tiling.py
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.tiling import (  # noqa: E402
+    MAX_TILES,
+    MIN_MODEL_PX,
+    Tile,
+    TileDetection,
+    box_iou,
+    containment,
+    is_truncated,
+    map_tile_box_to_frame,
+    merge_tile_detections,
+    plan_tiles,
+    select_tiles,
+    sweep_cycles,
+    tile_grid_overflowed,
+)
+
+
+class TestPlanTiles(unittest.TestCase):
+    def test_tile_zero_is_always_the_full_frame(self):
+        for w, h in [(1920, 1080), (2592, 1944), (640, 640), (4000, 600)]:
+            plan = plan_tiles(w, h, 640, 640, 60)
+            self.assertTrue(plan[0].full_frame)
+            self.assertEqual(plan[0].box, (0, 0, w, h))
+
+    def test_1080p_grid_covers_the_frame(self):
+        plan = plan_tiles(1920, 1080, 640, 640, 60)
+        self.assertGreater(len(plan), 1)
+        # Every column of the frame must fall inside at least one non-full tile.
+        crops = [t for t in plan if not t.full_frame]
+        for x in range(0, 1920, 37):
+            self.assertTrue(
+                any(t.left <= x < t.right for t in crops),
+                f"column {x} uncovered",
+            )
+
+    def test_5mp_grid_covers_both_axes(self):
+        plan = plan_tiles(2592, 1944, 640, 640, 60)
+        crops = [t for t in plan if not t.full_frame]
+        self.assertGreater(len(crops), 1)
+        for y in range(0, 1944, 41):
+            self.assertTrue(any(t.top <= y < t.bottom for t in crops), f"row {y}")
+        for x in range(0, 2592, 41):
+            self.assertTrue(any(t.left <= x < t.right for t in crops), f"col {x}")
+
+    def test_crops_are_uniformly_sized(self):
+        # The backend letterboxes each crop independently, so a short edge tile would
+        # be scaled differently from its neighbours. Last row/col flush to the edge.
+        plan = plan_tiles(2592, 1944, 640, 640, 60)
+        crops = [t for t in plan if not t.full_frame]
+        widths = {t.width for t in crops}
+        heights = {t.height for t in crops}
+        self.assertEqual(len(widths), 1, f"ragged widths: {widths}")
+        self.assertEqual(len(heights), 1, f"ragged heights: {heights}")
+
+    def test_crops_stay_inside_the_frame(self):
+        plan = plan_tiles(1920, 1080, 640, 640, 45)
+        for t in plan:
+            self.assertGreaterEqual(t.left, 0)
+            self.assertGreaterEqual(t.top, 0)
+            self.assertLessEqual(t.right, 1920)
+            self.assertLessEqual(t.bottom, 1080)
+
+    def test_degenerate_case_collapses_to_full_frame(self):
+        # One crop already covers the frame: tiling would re-inspect the same pixels
+        # at the same scale, so the grid must collapse rather than pay twice.
+        self.assertEqual(len(plan_tiles(640, 480, 640, 640, 60)), 1)
+        self.assertEqual(len(plan_tiles(1500, 1200, 640, 640, 60)), 1)
+
+    def test_native_scale_request_still_tiles(self):
+        # min_object_px == MIN_MODEL_PX asks for native scale: a 640 crop out of a
+        # larger frame is a real gain, so this must NOT collapse.
+        plan = plan_tiles(1000, 800, 640, 640, MIN_MODEL_PX)
+        self.assertGreater(len(plan), 1)
+        crop = [t for t in plan if not t.full_frame][0]
+        self.assertEqual((crop.width, crop.height), (640, 640))
+
+    def test_required_scale_actually_resolves_the_target_object(self):
+        # The point of the whole exercise: a min_object_px object must survive the
+        # crop -> model-input scaling at or above MIN_MODEL_PX.
+        min_object_px = 60
+        plan = plan_tiles(2592, 1944, 640, 640, min_object_px)
+        crop = [t for t in plan if not t.full_frame][0]
+        scale = min(640 / crop.width, 640 / crop.height)
+        self.assertGreaterEqual(min_object_px * scale, MIN_MODEL_PX - 1e-6)
+
+    def test_extreme_aspect_ratio(self):
+        plan = plan_tiles(4000, 400, 640, 640, 60)
+        crops = [t for t in plan if not t.full_frame]
+        for x in range(0, 4000, 53):
+            self.assertTrue(any(t.left <= x < t.right for t in crops), f"col {x}")
+
+    def test_grid_is_capped_and_overflow_is_reported(self):
+        # A very small min_object_px explodes the grid; the cap holds and the
+        # companion predicate tells the caller it was truncated.
+        plan = plan_tiles(4000, 3000, 640, 640, 2000)
+        self.assertLessEqual(len(plan), MAX_TILES)
+        if len(plan) == MAX_TILES:
+            self.assertTrue(
+                tile_grid_overflowed(4000, 3000, 640, 640, 2000)
+            )
+
+    def test_overflow_predicate_false_for_normal_grids(self):
+        self.assertFalse(tile_grid_overflowed(1920, 1080, 640, 640, 60))
+        self.assertFalse(tile_grid_overflowed(640, 480, 640, 640, 60))
+
+    def test_invalid_inputs_fall_back_to_full_frame(self):
+        self.assertEqual(len(plan_tiles(1920, 1080, 640, 640, 0)), 1)
+        self.assertEqual(len(plan_tiles(1920, 1080, 640, 640, -5)), 1)
+        self.assertEqual(len(plan_tiles(0, 0, 640, 640, 60)), 1)
+
+    def test_bad_overlap_raises(self):
+        with self.assertRaises(ValueError):
+            plan_tiles(1920, 1080, 640, 640, 60, overlap=1.0)
+        with self.assertRaises(ValueError):
+            plan_tiles(1920, 1080, 640, 640, 60, overlap=-0.1)
+
+
+class TestSelectTiles(unittest.TestCase):
+    def setUp(self):
+        self.plan = plan_tiles(2592, 1944, 640, 640, 60)
+
+    def test_budget_is_exact(self):
+        for budget in (2, 3, 4):
+            selected = select_tiles(self.plan, budget, 1.0, 1000.0)
+            self.assertEqual(len(selected), min(budget, len(self.plan)))
+
+    def test_content_never_changes_the_budget(self):
+        # The invariant the design exists to protect: selection depends only on the
+        # clock and the plan, never on anything scene-derived.
+        sizes = {
+            len(select_tiles(self.plan, 3, 1.0, float(t))) for t in range(0, 100)
+        }
+        self.assertEqual(sizes, {3})
+
+    def test_full_frame_always_included(self):
+        for t in range(0, 50):
+            selected = select_tiles(self.plan, 3, 1.0, float(t))
+            self.assertTrue(selected[0].full_frame)
+
+    def test_selection_is_stateless_and_repeatable(self):
+        a = select_tiles(self.plan, 3, 1.0, 1234.0)
+        b = select_tiles(self.plan, 3, 1.0, 1234.0)
+        self.assertEqual([t.index for t in a], [t.index for t in b])
+
+    def test_no_duplicate_tiles_within_one_cycle(self):
+        for t in range(0, 50):
+            selected = select_tiles(self.plan, 3, 1.0, float(t))
+            indices = [x.index for x in selected]
+            self.assertEqual(len(indices), len(set(indices)))
+
+    def test_every_tile_visited_within_the_sweep_bound(self):
+        budget = 3
+        cycles = sweep_cycles(len(self.plan), budget)
+        seen = set()
+        for step in range(cycles):
+            for tile in select_tiles(self.plan, budget, 1.0, float(step)):
+                seen.add(tile.index)
+        self.assertEqual(
+            seen, {t.index for t in self.plan},
+            f"not all tiles visited in {cycles} cycles: missing "
+            f"{ {t.index for t in self.plan} - seen }",
+        )
+
+    def test_no_starvation_over_a_long_run(self):
+        counts = {t.index: 0 for t in self.plan}
+        for step in range(200):
+            for tile in select_tiles(self.plan, 3, 1.0, float(step)):
+                counts[tile.index] += 1
+        for index, count in counts.items():
+            self.assertGreater(count, 0, f"tile {index} starved")
+
+    def test_slow_caller_covers_everything_when_tile_period_matches(self):
+        # A caller on lightNVR's keyframe-gated path fires at the GOP length rather
+        # than the configured detection_interval. Told the truth via tile_period,
+        # coverage is complete.
+        seen = set()
+        for step in range(0, 60, 2):  # fires every 2s, tile_period=2
+            for tile in select_tiles(self.plan, 3, 2.0, float(step)):
+                seen.add(tile.index)
+        self.assertEqual(seen, {t.index for t in self.plan})
+
+    def test_commensurate_period_mismatch_starves_tiles(self):
+        # Pinned failure mode, not aspiration. The cursor advances linearly with the
+        # clock, so a caller whose period is an exact multiple of tile_period samples
+        # the same residues forever. Half this grid is never visited. tile_period is
+        # the remedy — see the test above and select_tiles' docstring.
+        seen = set()
+        for step in range(0, 60, 2):  # fires every 2s but claims tile_period=1
+            for tile in select_tiles(self.plan, 3, 1.0, float(step)):
+                seen.add(tile.index)
+        self.assertNotEqual(
+            seen, {t.index for t in self.plan},
+            "aliasing was expected here; if this now passes the cursor changed and "
+            "the docstring's contract should be relaxed to match",
+        )
+        self.assertEqual(seen, {0, 1, 2})
+
+    def test_budget_of_one_returns_only_the_full_frame(self):
+        selected = select_tiles(self.plan, 1, 1.0, 5.0)
+        self.assertEqual(len(selected), 1)
+        self.assertTrue(selected[0].full_frame)
+
+    def test_budget_larger_than_grid_is_clamped(self):
+        selected = select_tiles(self.plan, 99, 1.0, 5.0)
+        self.assertEqual(len(selected), len(self.plan))
+
+    def test_collapsed_plan_is_handled(self):
+        plan = plan_tiles(640, 480, 640, 640, 60)
+        self.assertEqual(len(select_tiles(plan, 4, 1.0, 7.0)), 1)
+
+    def test_empty_plan_is_handled(self):
+        self.assertEqual(select_tiles([], 4, 1.0, 7.0), [])
+
+    def test_sweep_bound_matches_the_plan_document(self):
+        # K=24 pool with T=4 sweeps in 8 cycles: at 1 Hz that is 8 s, inside a
+        # walking person's dwell time. This is the number the design rests on.
+        self.assertEqual(sweep_cycles(25, 4), 8)
+
+
+class TestCoordinateMapping(unittest.TestCase):
+    def test_full_frame_tile_is_identity(self):
+        tile = Tile(0, 0, 0, 1920, 1080, full_frame=True)
+        box = (0.1, 0.2, 0.3, 0.4)
+        mapped = map_tile_box_to_frame(box, tile, 1920, 1080)
+        for got, want in zip(mapped, box):
+            self.assertAlmostEqual(got, want, places=9)
+
+    def test_round_trip_through_the_crop_rect_is_identity(self):
+        tile = Tile(1, 320, 200, 1920, 1000)
+        for box in [
+            (0.0, 0.0, 1.0, 1.0),
+            (0.25, 0.5, 0.75, 0.9),
+            (0.4, 0.4, 0.45, 0.45),
+        ]:
+            frame_box = map_tile_box_to_frame(box, tile, 1920, 1080)
+            # Invert: frame-normalized -> pixels -> tile-normalized.
+            back = (
+                (frame_box[0] * 1920 - tile.left) / tile.width,
+                (frame_box[1] * 1080 - tile.top) / tile.height,
+                (frame_box[2] * 1920 - tile.left) / tile.width,
+                (frame_box[3] * 1080 - tile.top) / tile.height,
+            )
+            for got, want in zip(back, box):
+                self.assertAlmostEqual(got, want, places=6)
+
+    def test_offset_tile_shifts_the_box(self):
+        tile = Tile(1, 960, 0, 1920, 1080)
+        mapped = map_tile_box_to_frame((0.0, 0.0, 1.0, 1.0), tile, 1920, 1080)
+        self.assertAlmostEqual(mapped[0], 0.5, places=9)
+        self.assertAlmostEqual(mapped[2], 1.0, places=9)
+
+    def test_results_are_clamped_to_the_unit_square(self):
+        tile = Tile(1, 1600, 0, 1920, 1080)
+        mapped = map_tile_box_to_frame((-0.5, -0.5, 1.5, 1.5), tile, 1920, 1080)
+        for value in mapped:
+            self.assertGreaterEqual(value, 0.0)
+            self.assertLessEqual(value, 1.0)
+
+    def test_degenerate_frame_does_not_divide_by_zero(self):
+        tile = Tile(0, 0, 0, 0, 0, full_frame=True)
+        self.assertEqual(map_tile_box_to_frame((0, 0, 1, 1), tile, 0, 0), (0.0, 0.0, 0.0, 0.0))
+
+
+class TestTruncation(unittest.TestCase):
+    def test_box_touching_an_interior_tile_edge_is_truncated(self):
+        tile = Tile(1, 0, 0, 1600, 1080)  # right edge is interior to a 1920 frame
+        self.assertTrue(is_truncated((0.5, 0.2, 1.0, 0.8), tile, 1920, 1080))
+
+    def test_box_touching_a_frame_edge_is_not_truncated(self):
+        tile = Tile(1, 320, 0, 1920, 1080)  # right edge IS the frame edge
+        self.assertFalse(is_truncated((0.5, 0.2, 1.0, 0.8), tile, 1920, 1080))
+
+    def test_left_frame_edge_is_not_truncated(self):
+        tile = Tile(1, 0, 0, 1600, 1080)
+        self.assertFalse(is_truncated((0.0, 0.2, 0.4, 0.8), tile, 1920, 1080))
+
+    def test_interior_box_is_not_truncated(self):
+        tile = Tile(1, 0, 0, 1600, 1080)
+        self.assertFalse(is_truncated((0.3, 0.3, 0.6, 0.6), tile, 1920, 1080))
+
+    def test_vertical_interior_edge_is_truncated(self):
+        tile = Tile(1, 0, 0, 1600, 800)  # bottom edge interior to a 1080 frame
+        self.assertTrue(is_truncated((0.3, 0.6, 0.6, 1.0), tile, 1920, 1080))
+
+
+class TestMerge(unittest.TestCase):
+    def test_duplicate_across_overlap_collapses_to_one(self):
+        a = TileDetection("person", 0.9, (0.50, 0.50, 0.60, 0.70), tile_index=1)
+        b = TileDetection("person", 0.8, (0.505, 0.505, 0.605, 0.705), tile_index=2)
+        merged = merge_tile_detections([a, b])
+        self.assertEqual(len(merged), 1)
+        self.assertAlmostEqual(merged[0].confidence, 0.9)
+
+    def test_distinct_objects_both_survive(self):
+        a = TileDetection("person", 0.9, (0.1, 0.1, 0.2, 0.3), tile_index=1)
+        b = TileDetection("person", 0.8, (0.7, 0.6, 0.8, 0.9), tile_index=2)
+        self.assertEqual(len(merge_tile_detections([a, b])), 2)
+
+    def test_different_labels_do_not_suppress_each_other(self):
+        a = TileDetection("person", 0.9, (0.5, 0.5, 0.6, 0.7), tile_index=1)
+        b = TileDetection("car", 0.8, (0.5, 0.5, 0.6, 0.7), tile_index=2)
+        self.assertEqual(len(merge_tile_detections([a, b])), 2)
+
+    def test_truncated_copy_loses_to_the_interior_copy(self):
+        # Same object: clipped at a tile seam in one tile, whole in another. The
+        # whole copy must win even though the fragment scored higher.
+        fragment = TileDetection("person", 0.95, (0.50, 0.50, 0.55, 0.70),
+                                 tile_index=1, truncated=True)
+        whole = TileDetection("person", 0.60, (0.50, 0.50, 0.60, 0.70),
+                              tile_index=2, truncated=False)
+        merged = merge_tile_detections([fragment, whole])
+        self.assertEqual(len(merged), 1)
+        self.assertFalse(merged[0].truncated)
+        self.assertEqual(merged[0].tile_index, 2)
+
+    def test_small_fragment_is_suppressed_by_containment_despite_low_iou(self):
+        # A sliver of a large object has poor IoU against the full box, so plain NMS
+        # would keep it as a phantom. Containment is what catches this.
+        whole = TileDetection("car", 0.9, (0.20, 0.20, 0.80, 0.80), tile_index=1)
+        sliver = TileDetection("car", 0.85, (0.20, 0.20, 0.28, 0.80),
+                               tile_index=2, truncated=True)
+        self.assertLess(box_iou(whole.box, sliver.box), 0.45)
+        merged = merge_tile_detections([whole, sliver])
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0].tile_index, 1)
+
+    def test_untruncated_sliver_is_kept(self):
+        # Containment only overrides for truncated boxes: a genuinely small object
+        # sitting inside a larger one's box is real and must survive.
+        big = TileDetection("car", 0.9, (0.2, 0.2, 0.8, 0.8), tile_index=1)
+        small = TileDetection("car", 0.7, (0.3, 0.3, 0.36, 0.4),
+                              tile_index=1, truncated=False)
+        self.assertEqual(len(merge_tile_detections([big, small])), 2)
+
+    def test_output_is_confidence_ordered(self):
+        dets = [
+            TileDetection("person", 0.30, (0.0, 0.0, 0.05, 0.05), tile_index=1),
+            TileDetection("person", 0.90, (0.2, 0.2, 0.25, 0.25), tile_index=1),
+            TileDetection("person", 0.60, (0.4, 0.4, 0.45, 0.45), tile_index=2),
+        ]
+        merged = merge_tile_detections(dets)
+        confidences = [d.confidence for d in merged]
+        self.assertEqual(confidences, sorted(confidences, reverse=True))
+
+    def test_empty_input(self):
+        self.assertEqual(merge_tile_detections([]), [])
+
+    def test_single_detection_passes_through(self):
+        d = TileDetection("person", 0.5, (0.1, 0.1, 0.2, 0.2), tile_index=0)
+        self.assertEqual(len(merge_tile_detections([d])), 1)
+
+
+class TestBoxMath(unittest.TestCase):
+    def test_iou_of_identical_boxes_is_one(self):
+        b = (0.1, 0.1, 0.5, 0.5)
+        self.assertAlmostEqual(box_iou(b, b), 1.0)
+
+    def test_iou_of_disjoint_boxes_is_zero(self):
+        self.assertEqual(box_iou((0.0, 0.0, 0.1, 0.1), (0.5, 0.5, 0.6, 0.6)), 0.0)
+
+    def test_iou_half_overlap(self):
+        a = (0.0, 0.0, 0.2, 0.1)
+        b = (0.1, 0.0, 0.3, 0.1)
+        # intersection 0.1x0.1, union 0.3x0.1 -> 1/3
+        self.assertAlmostEqual(box_iou(a, b), 1.0 / 3.0, places=9)
+
+    def test_containment_of_fully_inside_box_is_one(self):
+        inner = (0.3, 0.3, 0.4, 0.4)
+        outer = (0.1, 0.1, 0.9, 0.9)
+        self.assertAlmostEqual(containment(inner, outer), 1.0)
+
+    def test_containment_of_disjoint_box_is_zero(self):
+        self.assertEqual(containment((0.0, 0.0, 0.1, 0.1), (0.5, 0.5, 0.9, 0.9)), 0.0)
+
+    def test_containment_of_zero_area_box_is_zero(self):
+        self.assertEqual(containment((0.5, 0.5, 0.5, 0.5), (0.1, 0.1, 0.9, 0.9)), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_tiling_integration.py
+++ b/tests/test_tiling_integration.py
@@ -1,0 +1,237 @@
+"""End-to-end geometry check for tiled detection, using real crops and a fake model.
+
+This is the test that would catch an off-by-one between a PIL crop rectangle and the
+normalization applied to boxes coming back from it — the failure mode that puts every
+detection slightly in the wrong place, which is easy to miss by eye and impossible to
+catch with pure-arithmetic tests.
+
+The "detector" is a perfect oracle: it finds the bright square in whatever crop it is
+handed and reports it in crop-normalized coordinates, exactly as a real backend does.
+So any drift between the true position and the merged output is the tiling code's.
+
+Needs PIL (a hard project dependency) but no model, no numpy and no pydantic.
+
+    python3 tests/test_tiling_integration.py      # or under pytest
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+try:
+    from PIL import Image, ImageDraw
+    HAVE_PIL = True
+except ImportError:  # pragma: no cover - PIL is a project dependency
+    HAVE_PIL = False
+
+from utils.tiling import (  # noqa: E402
+    TileDetection,
+    is_truncated,
+    map_tile_box_to_frame,
+    merge_tile_detections,
+    plan_tiles,
+    select_tiles,
+)
+
+FRAME_W, FRAME_H = 2592, 1944
+MODEL_W, MODEL_H = 640, 640
+MIN_OBJECT_PX = 60
+
+
+def make_frame(rects):
+    """Black frame with white rectangles at the given pixel boxes."""
+    image = Image.new("RGB", (FRAME_W, FRAME_H), (0, 0, 0))
+    for (left, top, right, bottom) in rects:
+        image.paste((255, 255, 255), (left, top, right, bottom))
+    return image
+
+
+def _components(mask, max_objects=64):
+    """Bounding boxes of each connected bright region.
+
+    A plain ``getbbox()`` would return the union of every bright pixel — one box
+    spanning all objects — which no real detector does. Reporting per-object boxes
+    matters here because the merge is specifically about deciding when two boxes are
+    the same object, and a union-bbox oracle would never exercise that.
+
+    Seeds are found from the first bright pixel on the top row of the remaining
+    bounding box, so no full-image Python scan is needed; the flood fills themselves
+    only touch object pixels.
+    """
+    work = mask.copy()
+    boxes = []
+    for _ in range(max_objects):
+        bbox = work.getbbox()
+        if bbox is None:
+            break
+        left, top, right, _bottom = bbox
+        row = work.crop((left, top, right, top + 1)).tobytes()
+        offset = next((i for i, value in enumerate(row) if value), None)
+        if offset is None:  # pragma: no cover - getbbox guarantees a bright pixel
+            break
+        ImageDraw.floodfill(work, (left + offset, top), 128)
+        component = work.point(lambda p: 255 if p == 128 else 0)
+        boxes.append(component.getbbox())
+        work = work.point(lambda p: 0 if p == 128 else p)
+    return boxes
+
+
+def oracle_detect(crop):
+    """Report each bright region in crop-normalized coordinates."""
+    mask = crop.convert("L").point(lambda p: 255 if p > 128 else 0)
+    w, h = crop.size
+    return [
+        (left / w, top / h, right / w, bottom / h)
+        for (left, top, right, bottom) in _components(mask)
+    ]
+
+
+def run_tiled(image, budget, now=0.0, tile_period=1.0):
+    """Mirror of the endpoint's orchestration, using the oracle as the backend."""
+    frame_w, frame_h = image.size
+    plan = plan_tiles(frame_w, frame_h, MODEL_W, MODEL_H, MIN_OBJECT_PX)
+    selected = select_tiles(plan, budget, tile_period, now)
+
+    collected = []
+    for tile in selected:
+        crop = image if tile.full_frame else image.crop(tile.box)
+        for box in oracle_detect(crop):
+            collected.append(
+                TileDetection(
+                    label="object",
+                    confidence=0.9,
+                    box=map_tile_box_to_frame(box, tile, frame_w, frame_h),
+                    tile_index=tile.index,
+                    truncated=(
+                        not tile.full_frame
+                        and is_truncated(box, tile, frame_w, frame_h)
+                    ),
+                )
+            )
+    return merge_tile_detections(collected), plan, selected
+
+
+def to_pixels(box):
+    return (
+        box[0] * FRAME_W,
+        box[1] * FRAME_H,
+        box[2] * FRAME_W,
+        box[3] * FRAME_H,
+    )
+
+
+@unittest.skipUnless(HAVE_PIL, "PIL not installed")
+class TestTiledGeometry(unittest.TestCase):
+    def assert_box_close(self, got_norm, expected_px, tol=2.0):
+        got = to_pixels(got_norm)
+        for axis, (g, e) in enumerate(zip(got, expected_px)):
+            self.assertLessEqual(
+                abs(g - e), tol,
+                f"axis {axis}: got {g:.1f}px, expected {e}px (tolerance {tol}px)\n"
+                f"  full box got={tuple(round(v,1) for v in got)} expected={expected_px}",
+            )
+
+    def test_object_lands_at_its_true_frame_position(self):
+        truth = (1400, 900, 1460, 960)
+        image = make_frame([truth])
+        merged, plan, _ = run_tiled(image, budget=len(plan_tiles(
+            FRAME_W, FRAME_H, MODEL_W, MODEL_H, MIN_OBJECT_PX)))
+        self.assertGreaterEqual(len(merged), 1)
+        self.assert_box_close(merged[0].box, truth)
+
+    def test_position_is_correct_from_every_tile_that_sees_it(self):
+        # The real risk: a tile-specific offset error that only shows up for crops
+        # away from the origin. Check each covering tile independently.
+        truth = (1400, 900, 1460, 960)
+        image = make_frame([truth])
+        plan = plan_tiles(FRAME_W, FRAME_H, MODEL_W, MODEL_H, MIN_OBJECT_PX)
+
+        covering = [
+            t for t in plan
+            if t.left <= truth[0] and t.top <= truth[1]
+            and t.right >= truth[2] and t.bottom >= truth[3]
+        ]
+        self.assertGreater(len(covering), 1, "expected the object inside several tiles")
+
+        for tile in covering:
+            crop = image if tile.full_frame else image.crop(tile.box)
+            boxes = oracle_detect(crop)
+            self.assertEqual(len(boxes), 1, f"tile {tile.index} saw nothing")
+            mapped = map_tile_box_to_frame(boxes[0], tile, FRAME_W, FRAME_H)
+            self.assert_box_close(mapped, truth)
+
+    def test_corner_objects_map_correctly(self):
+        for truth in [
+            (0, 0, 60, 60),                              # top-left
+            (FRAME_W - 60, 0, FRAME_W, 60),              # top-right
+            (0, FRAME_H - 60, 60, FRAME_H),              # bottom-left
+            (FRAME_W - 60, FRAME_H - 60, FRAME_W, FRAME_H),  # bottom-right
+        ]:
+            with self.subTest(truth=truth):
+                image = make_frame([truth])
+                full_budget = len(plan_tiles(
+                    FRAME_W, FRAME_H, MODEL_W, MODEL_H, MIN_OBJECT_PX))
+                merged, _, _ = run_tiled(image, budget=full_budget)
+                self.assertGreaterEqual(len(merged), 1)
+                self.assert_box_close(merged[0].box, truth)
+
+    def test_object_on_a_tile_seam_is_not_duplicated(self):
+        # An object straddling a seam is seen whole by the full-frame tile and
+        # clipped by at least one crop. Exactly one box should survive the merge.
+        plan = plan_tiles(FRAME_W, FRAME_H, MODEL_W, MODEL_H, MIN_OBJECT_PX)
+        seam = [t.right for t in plan if not t.full_frame and t.right < FRAME_W][0]
+        truth = (seam - 40, 900, seam + 40, 980)
+        image = make_frame([truth])
+
+        merged, _, _ = run_tiled(image, budget=len(plan))
+        self.assertEqual(
+            len(merged), 1,
+            f"expected one merged box, got {[to_pixels(m.box) for m in merged]}",
+        )
+        self.assert_box_close(merged[0].box, truth)
+
+    def test_two_distinct_objects_both_reported(self):
+        a = (300, 300, 360, 360)
+        b = (2100, 1500, 2160, 1560)
+        image = make_frame([a, b])
+        full_budget = len(plan_tiles(FRAME_W, FRAME_H, MODEL_W, MODEL_H, MIN_OBJECT_PX))
+        merged, _, _ = run_tiled(image, budget=full_budget)
+        self.assertEqual(
+            len(merged), 2,
+            f"both objects should survive: got {[to_pixels(m.box) for m in merged]}",
+        )
+
+        by_x = sorted(merged, key=lambda m: m.box[0])
+        self.assert_box_close(by_x[0].box, a)
+        self.assert_box_close(by_x[1].box, b)
+
+    def test_empty_frame_yields_nothing(self):
+        image = Image.new("RGB", (FRAME_W, FRAME_H), (0, 0, 0))
+        merged, _, _ = run_tiled(image, budget=4)
+        self.assertEqual(merged, [])
+
+    def test_budget_is_respected_exactly(self):
+        image = make_frame([(1400, 900, 1460, 960)])
+        plan = plan_tiles(FRAME_W, FRAME_H, MODEL_W, MODEL_H, MIN_OBJECT_PX)
+        for budget in (1, 2, 3):
+            _, _, selected = run_tiled(image, budget=budget)
+            self.assertEqual(len(selected), min(budget, len(plan)))
+
+    def test_cost_is_independent_of_scene_content(self):
+        # The invariant the whole design protects: an empty frame and a busy one
+        # must issue exactly the same number of inferences.
+        empty = Image.new("RGB", (FRAME_W, FRAME_H), (0, 0, 0))
+        busy = make_frame([
+            (x, y, x + 50, y + 50)
+            for x in range(100, 2400, 400)
+            for y in range(100, 1800, 400)
+        ])
+        _, _, sel_empty = run_tiled(empty, budget=3)
+        _, _, sel_busy = run_tiled(busy, budget=3)
+        self.assertEqual(len(sel_empty), len(sel_busy))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/utils/image.py
+++ b/utils/image.py
@@ -1,5 +1,5 @@
 import os
-from typing import Tuple, List
+from typing import Tuple, List, Optional
 from PIL import Image
 import io
 
@@ -38,12 +38,16 @@ def validate_image(image: Image.Image, filename: str) -> None:
         raise ValueError(f"Invalid image dimensions: {image.width}x{image.height}")
 
 
-def preprocess_image(image: Image.Image) -> Image.Image:
+def preprocess_image(image: Image.Image, max_size: Optional[int] = None) -> Image.Image:
     """
     Preprocess image for detection.
 
     Args:
         image: PIL Image to preprocess
+        max_size: Longest-side cap in pixels. Defaults to settings.MAX_IMAGE_SIZE.
+            Detection passes settings.MAX_DETECTION_IMAGE_SIZE so full resolution
+            survives to the backend, which letterboxes to model input itself — an
+            intermediate downscale here only costs small objects.
 
     Returns:
         Preprocessed PIL Image
@@ -61,7 +65,8 @@ def preprocess_image(image: Image.Image) -> Image.Image:
         image = background
 
     # Resize if image is too large
-    max_size = settings.MAX_IMAGE_SIZE
+    if max_size is None:
+        max_size = settings.MAX_IMAGE_SIZE
     if image.width > max_size or image.height > max_size:
         # Calculate new dimensions while preserving aspect ratio
         if image.width > image.height:

--- a/utils/tiling.py
+++ b/utils/tiling.py
@@ -12,9 +12,9 @@ an inference runtime. Callers adapt to and from their own detection types at the
 Boxes are ``(x_min, y_min, x_max, y_max)`` normalized to whatever frame they belong to.
 """
 
-from dataclasses import dataclass, replace
-from math import ceil
-from typing import Iterable, List, Optional, Sequence, Tuple
+from dataclasses import dataclass
+from math import ceil, floor
+from typing import Iterable, List, Sequence, Tuple
 
 Box = Tuple[float, float, float, float]
 
@@ -74,6 +74,22 @@ class TileDetection:
     truncated: bool = False
 
 
+def _region_size(model_dim: int, required_scale: float) -> int:
+    """Crop size along one axis that keeps a ``min_object_px`` object at MIN_MODEL_PX.
+
+    Rounds **down**. A crop of ``region`` letterboxed to ``model_dim`` scales a source
+    object by ``model_dim / region``, so the invariant needs
+    ``region <= model_dim / required_scale``. Rounding up overshoots that bound and
+    lands the object fractionally *under* MIN_MODEL_PX — the opposite of the guarantee
+    this module advertises. The error is sub-pixel, but floor costs nothing and makes
+    the code match the docstring.
+
+    Shared by plan_tiles and tile_grid_overflowed so the two cannot disagree about how
+    big a tile is, and therefore cannot disagree about whether the grid overflowed.
+    """
+    return max(1, int(floor(model_dim / required_scale)))
+
+
 def _axis_starts(total: int, region: int, stride: int) -> List[int]:
     """Crop origins along one axis, last one flush to the far edge.
 
@@ -131,8 +147,8 @@ def plan_tiles(
     if required_scale <= 0:
         return [full]
 
-    region_w = min(img_w, int(ceil(model_w / required_scale)))
-    region_h = min(img_h, int(ceil(model_h / required_scale)))
+    region_w = min(img_w, _region_size(model_w, required_scale))
+    region_h = min(img_h, _region_size(model_h, required_scale))
 
     # Degenerate: one crop already covers the frame, so tiling would re-inspect the
     # same pixels at the same scale. Tile 0 alone is strictly cheaper and identical.
@@ -179,8 +195,8 @@ def tile_grid_overflowed(
     if img_w <= 0 or img_h <= 0 or model_w <= 0 or model_h <= 0:
         return False
     required_scale = MIN_MODEL_PX / float(min_object_px)
-    region_w = min(img_w, int(ceil(model_w / required_scale)))
-    region_h = min(img_h, int(ceil(model_h / required_scale)))
+    region_w = min(img_w, _region_size(model_w, required_scale))
+    region_h = min(img_h, _region_size(model_h, required_scale))
     if region_w >= img_w and region_h >= img_h:
         return False
     stride_w = int(region_w * (1.0 - overlap))

--- a/utils/tiling.py
+++ b/utils/tiling.py
@@ -1,0 +1,379 @@
+"""Fixed-budget tiled detection: geometry, tile selection and cross-tile merge.
+
+The invariant this module exists to hold: **a request runs exactly T inferences**,
+T being a caller-supplied constant. Scene content never changes T — it only changes
+which T regions get looked at. Cost per request is therefore flat whether the frame
+is empty or a tree is thrashing in the wind.
+
+Everything here is a pure function over plain numbers. No PIL, no numpy, no pydantic,
+no model — so tests/test_tiling.py exercises the whole module without a model file or
+an inference runtime. Callers adapt to and from their own detection types at the edges.
+
+Boxes are ``(x_min, y_min, x_max, y_max)`` normalized to whatever frame they belong to.
+"""
+
+from dataclasses import dataclass, replace
+from math import ceil
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+Box = Tuple[float, float, float, float]
+
+# Smallest object, in *model input* pixels, that a YOLO-family grid reliably fires on.
+# Used to convert a desired source-pixel object size into a required crop scale.
+MIN_MODEL_PX = 24
+
+# Hard ceiling on grid size. Sized against sweep time, not memory: at 1 Hz with T=4 a
+# 24-tile grid sweeps in 8 s, inside a walking person's dwell time in frame. Much past
+# ~30 the sweep outlasts the dwell and the coverage argument stops holding.
+MAX_TILES = 32
+
+
+@dataclass(frozen=True)
+class Tile:
+    """A crop rectangle in source-frame pixel coordinates.
+
+    ``full_frame`` marks tile 0, which is always present and always selected, so
+    large and near objects are still caught every cycle and behaviour never
+    regresses below the untiled path.
+    """
+
+    index: int
+    left: int
+    top: int
+    right: int
+    bottom: int
+    full_frame: bool = False
+
+    @property
+    def width(self) -> int:
+        return self.right - self.left
+
+    @property
+    def height(self) -> int:
+        return self.bottom - self.top
+
+    @property
+    def box(self) -> Tuple[int, int, int, int]:
+        """Crop rect in PIL's ``(left, upper, right, lower)`` order."""
+        return (self.left, self.top, self.right, self.bottom)
+
+
+@dataclass(frozen=True)
+class TileDetection:
+    """A detection mapped into frame-normalized space, carrying its provenance.
+
+    ``truncated`` means the box touches a tile edge that is *not* also a frame edge,
+    so the object is probably clipped and this copy is partial. The merge prefers a
+    non-truncated copy of the same object from a neighbouring tile.
+    """
+
+    label: str
+    confidence: float
+    box: Box
+    tile_index: int
+    truncated: bool = False
+
+
+def _axis_starts(total: int, region: int, stride: int) -> List[int]:
+    """Crop origins along one axis, last one flush to the far edge.
+
+    Flushing rather than letting the final crop overhang keeps every tile the same
+    size, which matters because the backend letterboxes each crop independently —
+    a short final tile would be scaled differently from its neighbours.
+    """
+    if region >= total:
+        return [0]
+    stride = max(1, stride)
+    starts = [0]
+    while starts[-1] + region < total:
+        nxt = starts[-1] + stride
+        if nxt + region >= total:
+            starts.append(total - region)
+            break
+        starts.append(nxt)
+    return starts
+
+
+def plan_tiles(
+    img_w: int,
+    img_h: int,
+    model_w: int,
+    model_h: int,
+    min_object_px: int,
+    overlap: float = 0.25,
+    max_tiles: int = MAX_TILES,
+) -> List[Tile]:
+    """Build the tile grid for one frame.
+
+    ``min_object_px`` is the smallest object, in *source* pixels, that should still
+    be resolvable. The crop size follows from it::
+
+        required_scale = MIN_MODEL_PX / min_object_px    # 24/60 = 0.40
+        region         = model_input / required_scale    # 640/0.40 = 1600 px
+        stride         = region * (1 - overlap)          # 25% overlap -> 1200 px
+
+    Tile 0 is always the full frame. When the computed region already covers the
+    frame, the grid collapses to that single tile rather than paying twice for the
+    same pixels.
+    """
+    full = Tile(index=0, left=0, top=0, right=img_w, bottom=img_h, full_frame=True)
+
+    if min_object_px is None or min_object_px <= 0:
+        return [full]
+    if img_w <= 0 or img_h <= 0 or model_w <= 0 or model_h <= 0:
+        return [full]
+    if not 0.0 <= overlap < 1.0:
+        raise ValueError(f"overlap must be in [0, 1), got {overlap}")
+    if max_tiles < 1:
+        return [full]
+
+    required_scale = MIN_MODEL_PX / float(min_object_px)
+    if required_scale <= 0:
+        return [full]
+
+    region_w = min(img_w, int(ceil(model_w / required_scale)))
+    region_h = min(img_h, int(ceil(model_h / required_scale)))
+
+    # Degenerate: one crop already covers the frame, so tiling would re-inspect the
+    # same pixels at the same scale. Tile 0 alone is strictly cheaper and identical.
+    if region_w >= img_w and region_h >= img_h:
+        return [full]
+
+    stride_w = int(region_w * (1.0 - overlap))
+    stride_h = int(region_h * (1.0 - overlap))
+
+    tiles = [full]
+    for top in _axis_starts(img_h, region_h, stride_h):
+        for left in _axis_starts(img_w, region_w, stride_w):
+            tiles.append(
+                Tile(
+                    index=len(tiles),
+                    left=left,
+                    top=top,
+                    right=left + region_w,
+                    bottom=top + region_h,
+                )
+            )
+
+    if len(tiles) > max_tiles:
+        # Keep tile 0 plus the first (max_tiles - 1) crops. Callers should treat this
+        # as a misconfiguration signal: min_object_px is set finer than the frame can
+        # sweep in reasonable time.
+        tiles = tiles[:max_tiles]
+
+    return tiles
+
+
+def tile_grid_overflowed(
+    img_w: int,
+    img_h: int,
+    model_w: int,
+    model_h: int,
+    min_object_px: int,
+    overlap: float = 0.25,
+    max_tiles: int = MAX_TILES,
+) -> bool:
+    """True when plan_tiles had to truncate the grid — worth logging a warning on."""
+    if min_object_px is None or min_object_px <= 0:
+        return False
+    if img_w <= 0 or img_h <= 0 or model_w <= 0 or model_h <= 0:
+        return False
+    required_scale = MIN_MODEL_PX / float(min_object_px)
+    region_w = min(img_w, int(ceil(model_w / required_scale)))
+    region_h = min(img_h, int(ceil(model_h / required_scale)))
+    if region_w >= img_w and region_h >= img_h:
+        return False
+    stride_w = int(region_w * (1.0 - overlap))
+    stride_h = int(region_h * (1.0 - overlap))
+    count = 1 + len(_axis_starts(img_h, region_h, stride_h)) * len(
+        _axis_starts(img_w, region_w, stride_w)
+    )
+    return count > max_tiles
+
+
+def select_tiles(
+    plan: Sequence[Tile],
+    budget: int,
+    tile_period: float,
+    now: float,
+) -> List[Tile]:
+    """Pick exactly ``budget`` tiles: tile 0 plus a time-rotated slice of the rest.
+
+    The cursor is derived from the clock, not from stored state — no per-stream
+    server state, no eviction, no multi-worker coordination, nothing to corrupt
+    across restarts. Two workers handling successive frames agree by construction.
+
+    **``tile_period`` must match how often the caller actually fires.** This is a
+    contract, not a hint. The cursor advances linearly with the clock, so a caller
+    whose period is an exact multiple of ``tile_period`` samples the same residues
+    forever and the tiles in between are never visited at all. Concretely, with a
+    4-tile pool and T=3, a caller firing every 2 s against ``tile_period=1`` selects
+    tiles 1 and 2 on every single cycle; tiles 3 and 4 starve permanently. Passing
+    ``tile_period=2`` restores full coverage.
+
+    The rate to match is the *effective* one, which on lightNVR's keyframe-gated
+    path is the GOP length rather than the configured ``detection_interval`` — those
+    differ whenever the interval is shorter than the keyframe spacing.
+
+    A coprime stride would absorb the mismatch, but it stretches the nominal sweep of
+    a 24-tile grid from 8 cycles to roughly 12, which is the wrong trade against a
+    misconfiguration that ``tile_period`` already fixes.
+
+    Minor drift is harmless: a tile is occasionally visited twice and another skipped
+    within a sweep, but coverage stays uniform over time. Only exact commensurability
+    starves.
+    """
+    if not plan:
+        return []
+    head = plan[0]
+    pool = list(plan[1:])
+    if budget <= 1 or not pool:
+        return [head]
+
+    n_rot = min(budget - 1, len(pool))
+    period = tile_period if tile_period and tile_period > 0 else 1.0
+    step = int(now // period)
+    cursor = (step * n_rot) % len(pool)
+
+    selected = [pool[(cursor + i) % len(pool)] for i in range(n_rot)]
+    return [head] + selected
+
+
+def sweep_cycles(plan_size: int, budget: int) -> int:
+    """Cycles needed to visit every tile once. ``ceil(K / (T-1))`` with K the pool."""
+    pool = max(0, plan_size - 1)
+    if pool == 0:
+        return 1
+    n_rot = max(1, min(budget - 1, pool))
+    return int(ceil(pool / float(n_rot)))
+
+
+def map_tile_box_to_frame(
+    box: Box,
+    tile: Tile,
+    frame_w: int,
+    frame_h: int,
+) -> Box:
+    """Convert a tile-normalized box to frame-normalized coordinates."""
+    if frame_w <= 0 or frame_h <= 0:
+        return (0.0, 0.0, 0.0, 0.0)
+
+    x_min, y_min, x_max, y_max = box
+    fx_min = (tile.left + x_min * tile.width) / frame_w
+    fx_max = (tile.left + x_max * tile.width) / frame_w
+    fy_min = (tile.top + y_min * tile.height) / frame_h
+    fy_max = (tile.top + y_max * tile.height) / frame_h
+
+    return (
+        _clamp01(fx_min),
+        _clamp01(fy_min),
+        _clamp01(fx_max),
+        _clamp01(fy_max),
+    )
+
+
+def is_truncated(
+    box: Box,
+    tile: Tile,
+    frame_w: int,
+    frame_h: int,
+    edge_epsilon: float = 0.01,
+) -> bool:
+    """True when a tile-normalized box touches a tile edge that isn't a frame edge.
+
+    Such a box is probably a clipped fragment of an object that continues into the
+    neighbouring tile, so its extent and confidence are both understated. A box
+    touching a *frame* edge is not truncated — nothing lies beyond it to recover.
+    """
+    x_min, y_min, x_max, y_max = box
+
+    if x_min <= edge_epsilon and tile.left > 0:
+        return True
+    if y_min <= edge_epsilon and tile.top > 0:
+        return True
+    if x_max >= 1.0 - edge_epsilon and tile.right < frame_w:
+        return True
+    if y_max >= 1.0 - edge_epsilon and tile.bottom < frame_h:
+        return True
+    return False
+
+
+def _clamp01(value: float) -> float:
+    if value < 0.0:
+        return 0.0
+    if value > 1.0:
+        return 1.0
+    return value
+
+
+def box_area(box: Box) -> float:
+    x_min, y_min, x_max, y_max = box
+    return max(0.0, x_max - x_min) * max(0.0, y_max - y_min)
+
+
+def box_iou(a: Box, b: Box) -> float:
+    """Intersection over union of two normalized boxes."""
+    inter = _intersection_area(a, b)
+    if inter <= 0.0:
+        return 0.0
+    union = box_area(a) + box_area(b) - inter
+    return inter / union if union > 0.0 else 0.0
+
+
+def containment(inner: Box, outer: Box) -> float:
+    """Fraction of ``inner``'s area that lies inside ``outer``."""
+    area = box_area(inner)
+    if area <= 0.0:
+        return 0.0
+    return _intersection_area(inner, outer) / area
+
+
+def _intersection_area(a: Box, b: Box) -> float:
+    x_min = max(a[0], b[0])
+    y_min = max(a[1], b[1])
+    x_max = min(a[2], b[2])
+    y_max = min(a[3], b[3])
+    if x_max <= x_min or y_max <= y_min:
+        return 0.0
+    return (x_max - x_min) * (y_max - y_min)
+
+
+def merge_tile_detections(
+    detections: Iterable[TileDetection],
+    iou_threshold: float = 0.45,
+    containment_threshold: float = 0.8,
+) -> List[TileDetection]:
+    """Class-aware NMS across tiles, biased against edge-truncated copies.
+
+    Ordering is ``(truncated, -confidence)``: every intact copy is considered before
+    any clipped one, so when the same object is seen whole in one tile and clipped in
+    another, the whole copy is kept and the fragment suppressed. Within a truncation
+    class, ordinary confidence ordering applies.
+
+    Plain IoU is not enough on its own — a small fragment of a large object can fall
+    below the IoU threshold against the full box and survive as a phantom duplicate.
+    The containment test catches that case: a truncated box mostly inside an already
+    kept box of the same label is dropped regardless of IoU.
+    """
+    ordered = sorted(detections, key=lambda d: (d.truncated, -d.confidence))
+
+    kept: List[TileDetection] = []
+    for candidate in ordered:
+        suppressed = False
+        for winner in kept:
+            if winner.label != candidate.label:
+                continue
+            if box_iou(winner.box, candidate.box) > iou_threshold:
+                suppressed = True
+                break
+            if (
+                candidate.truncated
+                and containment(candidate.box, winner.box) >= containment_threshold
+            ):
+                suppressed = True
+                break
+        if not suppressed:
+            kept.append(candidate)
+
+    kept.sort(key=lambda d: -d.confidence)
+    return kept


### PR DESCRIPTION
Recovers small-object detection accuracy by removing a redundant downscale and adding an optional fixed-budget tiling mode. Independent of #6 — no overlapping files.

## The problem

Frames are downscaled twice before reaching the model. `preprocess_image` caps the longest side at `MAX_IMAGE_SIZE = 1024`, then the backend letterboxes that down to model input (640 for YOLO).

For 1080p that is 1920 → 1024 → 640, a net linear scale of **0.333** across two resamples. At 5 MP it is 0.247. A person 60 px tall in the source arrives at the model as 20 px — right at the floor where YOLO stops firing. The 1024 cap buys nothing, because the backend letterboxes anyway; it only costs a resample.

## Two changes

**1. `preprocess_image` gains an optional `max_size`.** `/v1/detect` passes a new `MAX_DETECTION_IMAGE_SIZE` (8192 — a sanity ceiling, not a working limit) so full resolution survives to the backend. `/describe` and `/query` keep the old 1024 default, since Moondream has its own sizing needs.

This alone is most of the win, and it applies to every request whether or not tiling is used.

**2. Optional tiled detection, off by default.** Per request, run exactly **T** inferences. Content never changes T — it only changes *which* T regions get inspected, so cost is flat whether the scene is empty or a tree is thrashing in the wind.

The grid is derived from `min_object_px` rather than being a fixed layout. Crop size is whatever makes the smallest interesting object land at the model's ~24 px detection floor:

```
crop size = model_input ÷ (24 / min_object_px)   →   640 ÷ (24/60) = 1600 px
```

Crops are laid on a 25%-overlap stride with the last row/column flushed to the frame edge. Tile 0 is always the whole frame, so large and near objects are caught every cycle and current behaviour never regresses. The remaining T−1 rotate over the pool on a clock-derived cursor — stateless, so there is no per-stream server state, nothing to evict, and no multi-worker constraint:

```python
cursor = int(now // tile_period) * n_rot % len(pool)
```

Grid sizes at `min_object_px=60`, 640 model:

| Resolution | Tiles | 60 px object reaches the model as | |
|---|---|---|---|
| | | via full frame | via a crop |
| 1080p | 3 | 20 px | **24 px** |
| 5 MP | 5 | 15 px | **24 px** |
| 4K | 7 | 10 px | **24 px** |

Cross-tile merge is class-aware NMS ordered by `(truncated, -confidence)`, so an object seen whole beats a copy clipped at a seam, plus a containment test — a sliver of a large object has poor IoU against the full box, and plain NMS would keep it as a phantom.

## Usage

No client changes needed. A stream's `model_path` may be a full URL with a query string, so this is configurable per camera:

```
http://detect-host:8000/api/v1/detect?stream=driveway&tiles=4&min_object_px=60&tile_period=1
```

Query params: `tiles` (T, default 1 = off), `min_object_px`, `tile_overlap`, `tile_period`, `tile_deadline_s`, `stream`.

## Cost

Measured on an i5-6500 / HD Graphics 530 with the OpenVINO provider, 5 MP frames: ~30 ms per inference, ~72 ms JPEG decode (paid once per request regardless of T). Six cameras at 1 Hz and T=4 is roughly 72% of that iGPU. Since T is a per-request parameter it is effectively per-camera — close-range cameras can run `tiles=1` and still benefit from change 1.

A `tile_deadline_s` limiter (default 7 s) stops issuing tiles and returns what it has, so a slow or degraded host degrades to partial coverage rather than hitting LightNVR's hard-coded 10 s client timeout. Tile 0 always runs before the deadline is consulted, so the worst case is current behaviour rather than an empty response.

## Backward compatibility

`tiles` absent or `1` takes the untiled path, and `DetectionResponse` is unchanged, so LightNVR's parser keeps working untouched.

Detection *values* on that path do change, because change 1 removes the downscale ahead of it. That is the intended improvement — only the response contract is frozen.

**This affects tflite and edgetpu too**, since `MAX_IMAGE_SIZE` lives on the shared endpoint. They will now receive full-resolution images and squash them harder in their bare `resize()`. Output geometry is unchanged (both normalise to their own input), so it is a quality shift rather than a correctness break — but it is untested on those backends, and worth a second opinion from someone with Coral hardware.

## Known limitation

`tile_period` must match the rate the caller **actually** fires at. The cursor is linear in the clock, so a caller whose period is an exact multiple of `tile_period` samples the same residues forever — permanent blind spots, not merely a slower sweep. With a 4-tile pool and T=3, a caller at 2 s against `tile_period=1` selects tiles 1 and 2 every cycle and never visits 3 or 4.

This matters because LightNVR's keyframe-gated fallback path fires at the GOP length, not at the configured `detection_interval`. A stride coprime to the pool size would absorb it, but that stretches a 24-tile sweep from 8 cycles to ~12, trading away the property the design rests on to paper over a misconfiguration that already has an exposed remedy. Documented in `select_tiles` and pinned by `test_commensurate_period_mismatch_starves_tiles` so it stays a known limitation rather than a field surprise.

## Testing

60 new tests, all stdlib-only and self-running under plain `python3` as well as pytest, following the pattern in `tests/test_onnx_providers.py`:

- `tests/test_tiling.py` — 52 tests. Grid planning at 1080p/5 MP/square/extreme aspect, the degenerate collapse to full frame, cursor sweep bounds and starvation, coordinate round-trips, truncation detection, merge behaviour, box maths.
- `tests/test_tiling_integration.py` — 8 tests. End-to-end geometry against real PIL crops with an oracle "detector", which is what would catch an off-by-one between a crop rectangle and the normalisation applied to boxes coming back from it. Needs PIL but no model, numpy or pydantic.

`utils/tiling.py` deliberately has zero third-party imports so the geometry is testable without a runtime installed.

Verified in a live LightNVR deployment: persons, TVs and lights are picked up at noticeably greater distances than before.
