### PR TITLE
Shape tiles to the model's aspect ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ In lightNVR, the API URL is typically:
 
 - `http://<docker-host>:8000/api/v1/detect`
 
+lightNVR passes that URL through verbatim, including any query string, so every
+option below can be set **per stream** from the stream's custom-endpoint field —
+no lightNVR changes required:
+
+```
+http://<docker-host>:8000/api/v1/detect?stream=driveway&filter_classes=person,car&tiles=4&min_object_px=60&tile_period=1
+```
+
+Unrecognised parameters are ignored, so a URL written for a newer server stays
+safe against an older one.
+
 ## API Endpoints
 
 - `GET /` - Root endpoint with API information
@@ -112,6 +123,68 @@ curl -X POST "http://localhost:9001/api/v1/detect" \
   -F "backend=tflite" \
   -F "confidence_threshold=0.5"
 ```
+
+### Tiled detection for small objects
+
+Distant objects are often too small to detect once a frame has been scaled down to
+the model's input. A 1080p frame reaching a 640 px YOLO model is scaled by 0.333,
+so a 60 px person arrives at 20 px — below the ~24 px where the model reliably
+fires.
+
+Tiled detection crops regions at a higher effective scale and rotates through them
+on a fixed budget. **Per request it runs exactly `tiles` inferences.** Scene content
+never changes that number — it only changes which regions get inspected — so cost is
+flat whether the frame is empty or a tree is thrashing in the wind.
+
+Tile 0 is always the whole frame, so large and near objects are still caught every
+cycle and behaviour never regresses. The remaining `tiles - 1` rotate over the grid
+on a clock-derived cursor, which needs no server-side state.
+
+| Parameter | Default | Meaning |
+|---|---|---|
+| `tiles` | `1` | Inferences per request. `1` disables tiling entirely. |
+| `min_object_px` | `60` | Smallest object to resolve, in **source** pixels. Drives crop size. |
+| `tile_overlap` | `0.25` | Overlap between adjacent crops, as a fraction of crop size. |
+| `tile_period` | `1.0` | Rotation period in seconds. **Must match the rate the caller actually fires at** — see below. |
+| `tile_deadline_s` | `7.0` | Stop issuing tiles once this many seconds have elapsed. |
+| `stream` | — | Stream name, logged for correlation. |
+
+```bash
+curl -X POST "http://localhost:8000/api/v1/detect?tiles=4&min_object_px=60&tile_period=1" \
+  -F "file=@frame.jpg"
+```
+
+**Choosing `min_object_px`.** This is the only setting that really matters. It is the
+smallest thing you want detected, measured in pixels *in the source frame* — so
+photograph the scene and measure a person at the distance you care about. Lower
+values magnify more but produce more tiles, which lengthens the rotation:
+
+| Frame | `min_object_px=60` | `=40` | `=24` (native) |
+|---|---|---|---|
+| 1080p | 3 tiles | 4 | 9 |
+| 5 MP | 5 tiles | 10 | 25 |
+| 4K | 7 tiles | 16 | 32 (capped) |
+
+If the grid exceeds 32 tiles it is truncated and a warning is logged — treat that as
+a signal that `min_object_px` is set finer than the frame can sweep in reasonable time.
+
+**Choosing `tiles`.** It is a per-request parameter, so set it per camera rather than
+globally. Close-range cameras can run `tiles=1` and still benefit from full-resolution
+detection. Spend the budget on the distant views. As a rough guide, on an Intel HD 530
+with the OpenVINO provider a 640 px YOLO inference costs ~30 ms, so six cameras at 1 Hz
+and `tiles=4` is around 70% of that GPU. Passing a `tiles` larger than the grid is
+harmless — the extra budget is simply not used.
+
+**`tile_period` must match your real detection rate.** The rotation cursor is derived
+from the clock, so a caller whose period is an exact multiple of `tile_period` will
+sample the same tiles forever and never visit the others — permanent blind spots, not
+merely a slower sweep. This matters because lightNVR's keyframe-gated path fires at the
+GOP length, not at the configured `detection_interval`. If a stream is gated on
+keyframes with a 2 s GOP, set `tile_period=2`.
+
+If the deadline is reached, remaining tiles are skipped and partial results returned.
+Tile 0 always runs first, so a slow or degraded host degrades to ordinary whole-frame
+behaviour rather than returning nothing.
 
 ## Adding New Backends
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ In lightNVR, the API URL is typically:
 - `http://<docker-host>:8000/api/v1/detect`
 
 lightNVR passes that URL through verbatim, including any query string, so every
-option below can be set **per stream** from the stream's custom-endpoint field —
+detection option can be set **per stream** from the stream's custom-endpoint field —
 no lightNVR changes required:
 
 ```
@@ -127,64 +127,22 @@ curl -X POST "http://localhost:9001/api/v1/detect" \
 ### Tiled detection for small objects
 
 Distant objects are often too small to detect once a frame has been scaled down to
-the model's input. A 1080p frame reaching a 640 px YOLO model is scaled by 0.333,
-so a 60 px person arrives at 20 px — below the ~24 px where the model reliably
-fires.
+the model's input — a 60 px person in a 1080p frame arrives at a 640 px YOLO model
+as 20 px, below the ~24 px where it reliably fires. Tiled detection crops regions at
+a higher effective scale and rotates through them on a fixed inference budget, so
+cost stays flat regardless of scene content.
 
-Tiled detection crops regions at a higher effective scale and rotates through them
-on a fixed budget. **Per request it runs exactly `tiles` inferences.** Scene content
-never changes that number — it only changes which regions get inspected — so cost is
-flat whether the frame is empty or a tree is thrashing in the wind.
-
-Tile 0 is always the whole frame, so large and near objects are still caught every
-cycle and behaviour never regresses. The remaining `tiles - 1` rotate over the grid
-on a clock-derived cursor, which needs no server-side state.
-
-| Parameter | Default | Meaning |
-|---|---|---|
-| `tiles` | `1` | Inferences per request. `1` disables tiling entirely. |
-| `min_object_px` | `60` | Smallest object to resolve, in **source** pixels. Drives crop size. |
-| `tile_overlap` | `0.25` | Overlap between adjacent crops, as a fraction of crop size. |
-| `tile_period` | `1.0` | Rotation period in seconds. **Must match the rate the caller actually fires at** — see below. |
-| `tile_deadline_s` | `7.0` | Stop issuing tiles once this many seconds have elapsed. |
-| `stream` | — | Stream name, logged for correlation. |
+Set it per request with `tiles`, `min_object_px` and `tile_period`, or server-wide
+with the `TILE_*` environment variables:
 
 ```bash
 curl -X POST "http://localhost:8000/api/v1/detect?tiles=4&min_object_px=60&tile_period=1" \
   -F "file=@frame.jpg"
 ```
 
-**Choosing `min_object_px`.** This is the only setting that really matters. It is the
-smallest thing you want detected, measured in pixels *in the source frame* — so
-photograph the scene and measure a person at the distance you care about. Lower
-values magnify more but produce more tiles, which lengthens the rotation:
-
-| Frame | `min_object_px=60` | `=40` | `=24` (native) |
-|---|---|---|---|
-| 1080p | 3 tiles | 4 | 9 |
-| 5 MP | 5 tiles | 10 | 25 |
-| 4K | 7 tiles | 16 | 32 (capped) |
-
-If the grid exceeds 32 tiles it is truncated and a warning is logged — treat that as
-a signal that `min_object_px` is set finer than the frame can sweep in reasonable time.
-
-**Choosing `tiles`.** It is a per-request parameter, so set it per camera rather than
-globally. Close-range cameras can run `tiles=1` and still benefit from full-resolution
-detection. Spend the budget on the distant views. As a rough guide, on an Intel HD 530
-with the OpenVINO provider a 640 px YOLO inference costs ~30 ms, so six cameras at 1 Hz
-and `tiles=4` is around 70% of that GPU. Passing a `tiles` larger than the grid is
-harmless — the extra budget is simply not used.
-
-**`tile_period` must match your real detection rate.** The rotation cursor is derived
-from the clock, so a caller whose period is an exact multiple of `tile_period` will
-sample the same tiles forever and never visit the others — permanent blind spots, not
-merely a slower sweep. This matters because lightNVR's keyframe-gated path fires at the
-GOP length, not at the configured `detection_interval`. If a stream is gated on
-keyframes with a 2 s GOP, set `tile_period=2`.
-
-If the deadline is reached, remaining tiles are skipped and partial results returned.
-Tile 0 always runs first, so a slow or degraded host degrades to ordinary whole-frame
-behaviour rather than returning nothing.
+See **[docs/TILED_DETECTION.md](docs/TILED_DETECTION.md)** for the full parameter
+reference, the matching `.env` variable names, how to choose `min_object_px` and
+`tiles`, and the `tile_period` aliasing trap that causes permanent blind spots.
 
 ## Adding New Backends
 
@@ -208,6 +166,8 @@ light-object-detect/
 │   ├── factory.py          # Backend factory
 │   └── tflite/             # TFLite backend
 │       └── backend.py      # TFLite implementation
+├── docs/                   # Reference documentation
+│   └── TILED_DETECTION.md  # Tiled detection parameters and tuning
 ├── models/                 # Data models
 │   └── detection.py        # Detection models
 ├── scripts/                # Utility scripts

--- a/docs/TILED_DETECTION.md
+++ b/docs/TILED_DETECTION.md
@@ -1,0 +1,126 @@
+# Tiled detection for small objects
+
+Distant objects are often too small to detect once a frame has been scaled down to
+the model's input. A 1080p frame reaching a 640 px YOLO model is scaled by 0.333,
+so a 60 px person arrives at 20 px — below the ~24 px where the model reliably
+fires.
+
+Tiled detection crops regions at a higher effective scale and rotates through them
+on a fixed budget. **Per request it runs exactly `tiles` inferences.** Scene content
+never changes that number — it only changes which regions get inspected — so cost is
+flat whether the frame is empty or a tree is thrashing in the wind.
+
+Tile 0 is always the whole frame, so large and near objects are still caught every
+cycle and behaviour never regresses. The remaining `tiles - 1` rotate over the grid
+on a clock-derived cursor, which needs no server-side state.
+
+## Parameters
+
+Every option can be set two ways: as a **query parameter** on `/api/v1/detect` for
+per-request control, or as an **environment variable** to change the default for the
+whole server. The query parameter wins when both are present.
+
+| Query parameter | `.env` variable | Default | Meaning |
+|---|---|---|---|
+| `tiles` | `TILE_BUDGET` | `1` | Inferences per request. `1` disables tiling entirely. |
+| `min_object_px` | `TILE_MIN_OBJECT_PX` | `60` | Smallest object to resolve, in **source** pixels. Drives crop size. |
+| `tile_overlap` | `TILE_OVERLAP` | `0.25` | Overlap between adjacent crops, as a fraction of crop size. |
+| `tile_period` | `TILE_PERIOD_SECONDS` | `1.0` | Rotation period in seconds. **Must match the rate the caller actually fires at** — see below. |
+| `tile_deadline_s` | `TILE_DEADLINE_SECONDS` | `7.0` | Stop issuing tiles once this many seconds have elapsed. |
+| `stream` | — | — | Stream name, logged for correlation. Per-request only. |
+| — | `TILE_IOU_THRESHOLD` | `0.45` | IoU threshold for cross-tile NMS. Server-wide only; no query parameter. |
+
+Note the name changes between the two forms: `min_object_px` is `TILE_MIN_OBJECT_PX`,
+`tile_period` is `TILE_PERIOD_SECONDS`, and `tile_deadline_s` is
+`TILE_DEADLINE_SECONDS`. The query names are shorter because they are typed into
+lightNVR stream URLs by hand.
+
+The 32-tile ceiling is the module constant `MAX_TILES` in `utils/tiling.py` and is not
+configurable from either place.
+
+## Setting defaults in `.env`
+
+Settings load from a `.env` file in the working directory (`config.py`, via
+`pydantic-settings`). Names are **case-sensitive** and must be upper-case exactly as
+listed above:
+
+```dotenv
+# Tiled detection
+TILE_BUDGET=4
+TILE_MIN_OBJECT_PX=60
+TILE_OVERLAP=0.25
+TILE_PERIOD_SECONDS=1.0
+TILE_DEADLINE_SECONDS=7.0
+TILE_IOU_THRESHOLD=0.45
+```
+
+In Docker the file is mounted at `/app/.env`:
+
+```yaml
+volumes:
+  - ./lod.env:/app/.env:ro
+```
+
+These values are read once at import time and become the query parameters' defaults,
+so **changing `.env` requires a container or process restart** to take effect. Query
+parameters need no restart, which is why per-camera tuning belongs in the stream URL.
+
+## Usage
+
+```bash
+curl -X POST "http://localhost:8000/api/v1/detect?tiles=4&min_object_px=60&tile_period=1" \
+  -F "file=@frame.jpg"
+```
+
+## Choosing `min_object_px`
+
+This is the only setting that really matters. It is the smallest thing you want
+detected, measured in pixels *in the source frame* — so photograph the scene and
+measure a person at the distance you care about. Lower values magnify more but
+produce more tiles, which lengthens the rotation:
+
+| Frame | `min_object_px=60` | `=40` | `=24` (native) |
+|---|---|---|---|
+| 1080p | 3 tiles | 4 | 9 |
+| 5 MP | 5 tiles | 10 | 25 |
+| 4K | 7 tiles | 16 | 32 (capped) |
+
+If the grid exceeds 32 tiles it is truncated and a warning is logged — treat that as
+a signal that `min_object_px` is set finer than the frame can sweep in reasonable time.
+
+## Choosing `tiles`
+
+It is a per-request parameter, so set it per camera rather than globally. Close-range
+cameras can run `tiles=1` and still benefit from full-resolution detection. Spend the
+budget on the distant views. As a rough guide, on an Intel HD 530 with the OpenVINO
+provider a 640 px YOLO inference costs ~30 ms, so six cameras at 1 Hz and `tiles=4` is
+around 70% of that GPU. Passing a `tiles` larger than the grid is harmless — the extra
+budget is simply not used.
+
+## `tile_period` must match your real detection rate
+
+The rotation cursor is derived from the clock, so a caller whose period is an exact
+multiple of `tile_period` will sample the same tiles forever and never visit the
+others — permanent blind spots, not merely a slower sweep. This matters because
+lightNVR's keyframe-gated path fires at the GOP length, not at the configured
+`detection_interval`. If a stream is gated on keyframes with a 2 s GOP, set
+`tile_period=2`.
+
+## Deadline behaviour
+
+If the deadline is reached, remaining tiles are skipped and partial results returned.
+Tile 0 always runs first, so a slow or degraded host degrades to ordinary whole-frame
+behaviour rather than returning nothing.
+
+## Per-stream configuration from lightNVR
+
+lightNVR passes the API URL through verbatim, including any query string, so every
+option above can be set per stream from the stream's custom-endpoint field — no
+lightNVR changes required:
+
+```
+http://<docker-host>:8000/api/v1/detect?stream=driveway&filter_classes=person,car&tiles=4&min_object_px=60&tile_period=1
+```
+
+Unrecognised parameters are ignored, so a URL written for a newer server stays safe
+against an older one.

--- a/tests/test_tiling.py
+++ b/tests/test_tiling.py
@@ -161,10 +161,20 @@ class TestTileShapeAndCoverage(unittest.TestCase):
     axis clamped to the frame and the other did not.
     """
 
-    RESOLUTIONS = [
+    # Landscape, the portrait transpose of each, and some extreme aspect ratios.
+    # Portrait matters because the sizing rule takes a min over both axes, so a bug
+    # that only shows when height binds before width would hide in landscape-only
+    # sweeps — which is exactly the class of bug this suite was written for.
+    _LANDSCAPE = [
         (1920, 1080), (2592, 1944), (3840, 2160),
         (1280, 720), (1600, 1200), (2048, 1536), (720, 576),
     ]
+    RESOLUTIONS = (
+        _LANDSCAPE
+        + [(h, w) for (w, h) in _LANDSCAPE]
+        + [(1080, 3840), (3840, 1080), (400, 1920), (1920, 400),
+           (1080, 1080), (500, 4000), (4000, 500)]
+    )
 
     def _crops(self, img_w, img_h, min_object_px):
         plan = plan_tiles(img_w, img_h, 640, 640, min_object_px)
@@ -267,6 +277,46 @@ class TestTileShapeAndCoverage(unittest.TestCase):
         # A 60px object clears the detection floor with room to spare, rather than
         # landing exactly on it as the old sizing did.
         self.assertGreater(60 * crop_scale, MIN_MODEL_PX * 1.4)
+
+    def test_a_portrait_frame_is_the_transpose_of_its_landscape_twin(self):
+        """Orientation must not change the grid, only rotate it.
+
+        The sizing rule takes a min over both axes, so it is symmetric by
+        construction — this pins that, and would catch any future change that
+        special-cases width. Truncated grids are excluded: the cap keeps tiles in
+        row-major order, so a grid and its transpose legitimately retain different
+        subsets once MAX_TILES bites.
+        """
+        for img_w, img_h in self._LANDSCAPE + [(3840, 1080), (400, 1920)]:
+            for min_object_px in range(20, 161, 4):
+                landscape = plan_tiles(img_w, img_h, 640, 640, min_object_px)
+                portrait = plan_tiles(img_h, img_w, 640, 640, min_object_px)
+                if len(landscape) == MAX_TILES or len(portrait) == MAX_TILES:
+                    continue
+                self.assertEqual(
+                    sorted((t.left, t.top, t.width, t.bottom - t.top) for t in landscape),
+                    sorted((t.top, t.left, t.bottom - t.top, t.width) for t in portrait),
+                    f"{img_w}x{img_h} and {img_h}x{img_w} at min_object_px="
+                    f"{min_object_px} are not transposes of each other",
+                )
+
+    def test_crops_stay_inside_the_frame(self):
+        for img_w, img_h in self.RESOLUTIONS:
+            for min_object_px in (24, 40, 60, 100):
+                _, crops = self._crops(img_w, img_h, min_object_px)
+                for tile in crops:
+                    self.assertGreaterEqual(tile.left, 0)
+                    self.assertGreaterEqual(tile.top, 0)
+                    self.assertLessEqual(
+                        tile.right, img_w,
+                        f"{img_w}x{img_h} min_object_px={min_object_px}: crop right "
+                        f"edge {tile.right} past the frame",
+                    )
+                    self.assertLessEqual(
+                        tile.bottom, img_h,
+                        f"{img_w}x{img_h} min_object_px={min_object_px}: crop bottom "
+                        f"edge {tile.bottom} past the frame",
+                    )
 
     def test_collapses_when_the_full_frame_already_resolves_the_target(self):
         # Tested on scale, not geometry: with aspect-matched crops a region can be

--- a/tests/test_tiling.py
+++ b/tests/test_tiling.py
@@ -153,6 +153,133 @@ class TestPlanTiles(unittest.TestCase):
             plan_tiles(1920, 1080, 640, 640, 60, overlap=-0.1)
 
 
+class TestTileShapeAndCoverage(unittest.TestCase):
+    """Properties of the grid itself, swept across resolutions and object sizes.
+
+    These exist because the original sizing rule computed each axis independently,
+    which silently produced crops shaped nothing like the model input whenever one
+    axis clamped to the frame and the other did not.
+    """
+
+    RESOLUTIONS = [
+        (1920, 1080), (2592, 1944), (3840, 2160),
+        (1280, 720), (1600, 1200), (2048, 1536), (720, 576),
+    ]
+
+    def _crops(self, img_w, img_h, min_object_px):
+        plan = plan_tiles(img_w, img_h, 640, 640, min_object_px)
+        return plan, [t for t in plan if not t.full_frame]
+
+    def test_crops_match_the_model_aspect_ratio(self):
+        # A crop shaped unlike the model input is letterboxed with grey bars, wasting
+        # part of the input and scaling by whichever axis is relatively larger. 1080p
+        # at min_object_px=60 used to produce 1600x1080 against a 640x640 input.
+        for img_w, img_h in self.RESOLUTIONS:
+            for min_object_px in range(20, 161, 4):
+                _, crops = self._crops(img_w, img_h, min_object_px)
+                for tile in crops:
+                    height = tile.bottom - tile.top
+                    self.assertAlmostEqual(
+                        tile.width / float(height), 1.0, places=2,
+                        msg=f"{img_w}x{img_h} min_object_px={min_object_px}: crop is "
+                            f"{tile.width}x{height} against a square model input",
+                    )
+
+    def test_crops_fill_the_model_input(self):
+        # The direct consequence of the above: no letterbox padding is wasted.
+        for img_w, img_h in self.RESOLUTIONS:
+            for min_object_px in (24, 40, 60, 80, 120):
+                _, crops = self._crops(img_w, img_h, min_object_px)
+                for tile in crops:
+                    height = tile.bottom - tile.top
+                    scale = min(640.0 / tile.width, 640.0 / height)
+                    used = (tile.width * scale) * (height * scale) / (640.0 * 640.0)
+                    self.assertGreater(
+                        used, 0.98,
+                        f"{img_w}x{img_h} min_object_px={min_object_px}: crop "
+                        f"{tile.width}x{height} uses only {used:.0%} of the model input",
+                    )
+
+    def test_adjacent_crops_never_leave_a_gap(self):
+        for img_w, img_h in self.RESOLUTIONS:
+            for min_object_px in range(20, 161, 4):
+                plan, crops = self._crops(img_w, img_h, min_object_px)
+                if not crops or len(plan) == MAX_TILES:
+                    continue  # a truncated grid is expected to be incomplete
+                width = crops[0].width
+                height = crops[0].bottom - crops[0].top
+                for axis, starts, size in (
+                    ("x", sorted({t.left for t in crops}), width),
+                    ("y", sorted({t.top for t in crops}), height),
+                ):
+                    for a, b in zip(starts, starts[1:]):
+                        self.assertLessEqual(
+                            b, a + size,
+                            f"{img_w}x{img_h} min_object_px={min_object_px}: {axis} "
+                            f"crops at {a} and {b} leave {b - (a + size)}px uncovered",
+                        )
+
+    def test_no_two_crops_are_near_duplicates(self):
+        # A crop that re-inspects pixels a neighbour already covered costs a whole
+        # inference and dilutes the rotation pool with a tile carrying no new
+        # information. Walking by stride and flushing the last crop to the edge used
+        # to produce pairs overlapping 97%.
+        for img_w, img_h in self.RESOLUTIONS:
+            for min_object_px in range(20, 161, 2):
+                plan, crops = self._crops(img_w, img_h, min_object_px)
+                if not crops or len(plan) == MAX_TILES:
+                    continue
+                width = crops[0].width
+                height = crops[0].bottom - crops[0].top
+                for axis, starts, size in (
+                    ("x", sorted({t.left for t in crops}), width),
+                    ("y", sorted({t.top for t in crops}), height),
+                ):
+                    for a, b in zip(starts, starts[1:]):
+                        overlap = (a + size - b) / float(size)
+                        self.assertLessEqual(
+                            overlap, 0.9,
+                            f"{img_w}x{img_h} min_object_px={min_object_px}: {axis} "
+                            f"crops at {a} and {b} overlap {overlap:.0%}",
+                        )
+
+    def test_1080p_gains_real_magnification(self):
+        """Regression pin for the case that motivated all of the above.
+
+        1080p is the common deployment resolution and the one where the frame height
+        binds before the requested scale does. The old per-axis sizing gave a
+        1600x1080 crop scaling at 0.400 — a 1.20x gain over the full frame for two
+        inferences. Aspect-matched sizing gives 1080x1080 at 0.593.
+        """
+        plan = plan_tiles(1920, 1080, 640, 640, 60)
+        crops = [t for t in plan if not t.full_frame]
+        self.assertTrue(crops, "1080p at min_object_px=60 should tile")
+
+        tile = crops[0]
+        self.assertEqual((tile.width, tile.bottom - tile.top), (1080, 1080))
+
+        crop_scale = 640.0 / 1080
+        full_scale = min(640.0 / 1920, 640.0 / 1080)
+        self.assertGreater(
+            crop_scale / full_scale, 1.7,
+            "the crop should magnify meaningfully more than the full frame",
+        )
+        # A 60px object clears the detection floor with room to spare, rather than
+        # landing exactly on it as the old sizing did.
+        self.assertGreater(60 * crop_scale, MIN_MODEL_PX * 1.4)
+
+    def test_collapses_when_the_full_frame_already_resolves_the_target(self):
+        # Tested on scale, not geometry: with aspect-matched crops a region can be
+        # smaller than the frame on both axes and still offer no gain.
+        for min_object_px in (80, 100, 200):
+            plan = plan_tiles(1920, 1080, 640, 640, min_object_px)
+            self.assertEqual(
+                len(plan), 1,
+                f"min_object_px={min_object_px} already resolves at full-frame scale "
+                f"{min(640/1920, 640/1080):.3f}, so tiling buys nothing",
+            )
+
+
 class TestSelectTiles(unittest.TestCase):
     def setUp(self):
         self.plan = plan_tiles(2592, 1944, 640, 640, 60)

--- a/utils/tiling.py
+++ b/utils/tiling.py
@@ -74,40 +74,83 @@ class TileDetection:
     truncated: bool = False
 
 
-def _region_size(model_dim: int, required_scale: float) -> int:
-    """Crop size along one axis that keeps a ``min_object_px`` object at MIN_MODEL_PX.
+def _region_dims(img_w: int, img_h: int, model_w: int, model_h: int,
+                 required_scale: float) -> Tuple[int, int]:
+    """Crop size that holds a ``min_object_px`` object at MIN_MODEL_PX, aspect-matched.
 
-    Rounds **down**. A crop of ``region`` letterboxed to ``model_dim`` scales a source
-    object by ``model_dim / region``, so the invariant needs
-    ``region <= model_dim / required_scale``. Rounding up overshoots that bound and
-    lands the object fractionally *under* MIN_MODEL_PX — the opposite of the guarantee
-    this module advertises. The error is sub-pixel, but floor costs nothing and makes
-    the code match the docstring.
+    **The crop must have the model's aspect ratio.** The backend letterboxes each crop
+    independently, so it scales by ``min(model_w/region_w, model_h/region_h)`` and pads
+    the slack axis with grey bars. A crop shaped unlike the model input therefore wastes
+    part of the input on padding *and* is scaled by whichever axis is relatively larger.
+
+    Sizing the axes independently — the obvious reading of "region = model / scale" —
+    gets this wrong whenever one axis clamps to the frame and the other does not. On
+    1080p at min_object_px=60 it yields a 1600x1080 crop against a 640x640 input: 32% of
+    the input is padding and the effective scale is 0.400, when a square 1080x1080 crop
+    of the same frame would give 0.593 for the same tile count.
+
+    So parameterise the crop as ``(model_w * t, model_h * t)`` and take the largest ``t``
+    that still fits the frame and still meets the scale requirement::
+
+        t = min(img_w/model_w, img_h/model_h, 1/required_scale)
+
+    The third term is the accuracy floor; the first two are the frame. Whichever binds,
+    the crop keeps the model's shape, so the letterbox never pads.
+
+    Rounds **down**, so ``region <= model_dim * t`` and the letterbox scale stays at or
+    above ``required_scale``. Rounding up would land the object fractionally under
+    MIN_MODEL_PX — the opposite of the guarantee this module advertises.
 
     Shared by plan_tiles and tile_grid_overflowed so the two cannot disagree about how
     big a tile is, and therefore cannot disagree about whether the grid overflowed.
     """
-    return max(1, int(floor(model_dim / required_scale)))
+    t = min(img_w / float(model_w), img_h / float(model_h), 1.0 / required_scale)
+    return max(1, int(floor(model_w * t))), max(1, int(floor(model_h * t)))
 
 
 def _axis_starts(total: int, region: int, stride: int) -> List[int]:
-    """Crop origins along one axis, last one flush to the far edge.
+    """Crop origins along one axis: first at 0, last flush to the far edge, evenly spread.
 
-    Flushing rather than letting the final crop overhang keeps every tile the same
-    size, which matters because the backend letterboxes each crop independently —
-    a short final tile would be scaled differently from its neighbours.
+    Every crop is the same size, which matters because the backend letterboxes each one
+    independently — a short final crop would be scaled differently from its neighbours.
+
+    Spacing them **evenly** rather than walking by ``stride`` and flushing the last one
+    is what keeps the axis gapless by construction. Walking-and-flushing puts the final
+    crop wherever the remainder falls, which can land it either almost on top of its
+    predecessor (a wasted inference that dilutes the rotation pool) or too far past it
+    (an uncovered strip). Distributing the span over a whole number of steps cannot do
+    either: the spacing is uniform, and capping it at ``region`` guarantees consecutive
+    crops touch.
+
+    The chosen spacing is at most the requested ``stride``, so the real overlap is always
+    at least what the caller asked for.
     """
     if region >= total:
         return [0]
     stride = max(1, stride)
-    starts = [0]
-    while starts[-1] + region < total:
-        nxt = starts[-1] + stride
-        if nxt + region >= total:
-            starts.append(total - region)
-            break
-        starts.append(nxt)
-    return starts
+    span = total - region
+
+    # A second crop that breaks little new ground is not worth an inference. Measured
+    # against the region, not the stride: what matters is the fraction of the crop that
+    # is new, and a stride-relative test lets through pairs overlapping 90%+ (4K at
+    # min_object_px=74 wanted crops at y=0 and y=187 of a 1973px region).
+    # The strip left uncovered is at most this fraction of the axis, and tile 0 — the
+    # full frame — still inspects it every cycle. It sits at the far edge, which for a
+    # fixed camera is foreground, where objects are large and magnification is moot.
+    if span < region * 0.15:
+        return [0]
+
+    # Number of gaps between starts. The stride term sets the overlap; the region term
+    # guarantees no gap even at overlap=0. The small tolerance stops a frame that
+    # overshoots the stride by a hair from buying a whole extra crop for it — 1920 wide
+    # with a 1080 region overshoots by 4%, and paying for a third column there would
+    # give 61% overlap where 25% was asked for.
+    steps = max(
+        1,
+        int(ceil(span / float(region))),
+        int(ceil(span / float(stride) - 0.05)),
+    )
+    return [int(round(i * span / float(steps))) for i in range(steps + 1)]
 
 
 def plan_tiles(
@@ -147,11 +190,13 @@ def plan_tiles(
     if required_scale <= 0:
         return [full]
 
-    region_w = min(img_w, _region_size(model_w, required_scale))
-    region_h = min(img_h, _region_size(model_h, required_scale))
+    # Degenerate: the full frame already resolves the target, so cropping would buy
+    # nothing. Tested on scale rather than geometry — with aspect-matched crops a
+    # region can be smaller than the frame on both axes yet still offer no gain.
+    if min(model_w / float(img_w), model_h / float(img_h)) >= required_scale:
+        return [full]
 
-    # Degenerate: one crop already covers the frame, so tiling would re-inspect the
-    # same pixels at the same scale. Tile 0 alone is strictly cheaper and identical.
+    region_w, region_h = _region_dims(img_w, img_h, model_w, model_h, required_scale)
     if region_w >= img_w and region_h >= img_h:
         return [full]
 
@@ -195,8 +240,10 @@ def tile_grid_overflowed(
     if img_w <= 0 or img_h <= 0 or model_w <= 0 or model_h <= 0:
         return False
     required_scale = MIN_MODEL_PX / float(min_object_px)
-    region_w = min(img_w, _region_size(model_w, required_scale))
-    region_h = min(img_h, _region_size(model_h, required_scale))
+    # Mirrors plan_tiles exactly, including the scale-based degenerate check.
+    if min(model_w / float(img_w), model_h / float(img_h)) >= required_scale:
+        return False
+    region_w, region_h = _region_dims(img_w, img_h, model_w, model_h, required_scale)
     if region_w >= img_w and region_h >= img_h:
         return False
     stride_w = int(region_w * (1.0 - overlap))


### PR DESCRIPTION
Follow-up to #8. Tile sizing produced crops shaped nothing like the model input on 1080p, which is both the most common deployment resolution and the case where the fix matters most.

## The problem

Tile size was computed per axis, independently:

```python
region_w = min(img_w, model_w / required_scale)
region_h = min(img_h, model_h / required_scale)
```

At 1080p with `min_object_px=60` the required region is 1600 px. The width doesn't clamp (frame is 1920) but the height does (frame is 1080), giving a **1600×1080 crop against a 640×640 model input**.

The backend letterboxes each crop independently — it scales by `min(model_w/region_w, model_h/region_h)` and pads the slack axis with grey bars. So that crop is scaled 0.400 by its wide axis and padded on its short one:

- **32% of the model input is grey padding**
- effective scale 0.400 vs 0.333 for the full frame — a **1.20× gain for two inferences**

The invariant technically held (a 60 px object did arrive at exactly 24 px) but the return was poor, and the wasted third of the input was pure loss.

## The fix

Parameterise the crop as `(model_w * t, model_h * t)` and take the largest `t` that both fits the frame and meets the scale requirement:

```
t = min(img_w/model_w, img_h/model_h, 1/required_scale)
```

The third term is the accuracy floor; the first two are the frame. Whichever binds, the crop keeps the model's shape, so the letterbox never pads.

| 1080p, `min_object_px=60` | before | after |
|---|---|---|
| crop | 1600×1080 | **1080×1080** |
| aspect vs 640×640 input | 1.48 | **1.00** |
| model input used | 68% | **100%** |
| effective scale | 0.400 | **0.593** |
| gain over full frame | 1.20× | **1.78×** |
| a 60 px object reaches | 24.0 px | **35.6 px** |
| tiles | 2 | 2 |

Same tile count. Nothing changes where the requested scale already bound before the frame did, so **5 MP and 4K grids are byte-identical to before** — this only touches the height-constrained case.

## Two consequences that had to be fixed with it

**The degenerate check moves from geometry to scale.** Asking whether the region covers the frame no longer answers the question, because an aspect-matched region can be smaller than the frame on both axes and still offer no gain. Comparing the full-frame letterbox scale directly against `required_scale` asks it properly, and correctly collapses 1080p at `min_object_px >= 80` to the full frame alone.

**`_axis_starts` now spaces crops evenly** rather than walking by stride and flushing the last one to the edge. Walking put the final crop wherever the remainder fell, which landed it either almost on top of its predecessor — 1920 wide with a 1080 region gave `[0, 810, 840]`, the last two **97% coincident**, spending a whole inference re-inspecting covered pixels and diluting the rotation pool — or, once the aspect fix changed the region sizes, too far past it, leaving up to **214 px uncovered**.

Even spacing can't do either. It's uniform by construction, capped at the region so consecutive crops always touch, and at most the requested stride so real overlap is never less than asked for.

A trailing crop that breaks less than 15% new ground is skipped rather than issued. Tile 0 covers that strip every cycle regardless, and it sits at the frame edge — for a fixed camera, foreground, where objects are large and magnification is moot.

## Verification

Swept **259 resolution × `min_object_px` combinations** across 1080p, 5 MP, 4K, 720p, 1200p, 1536p and PAL: no gaps, no near-duplicate crops, every crop aspect-matched, largest skipped sliver 12.9% of an axis.

Six new tests in `TestTileShapeAndCoverage`. **Four fail against the previous code**; the other two guard properties that already held and must keep holding. I checked that rather than assuming it — the suite in #8 shipped with a test that passed vacuously, and I'd rather not repeat it.

67 tests total (59 unit + 8 integration), all green, still stdlib-only and self-running under plain `python3`.
